### PR TITLE
[Feat/#8]: 공통 컴포넌트 생성

### DIFF
--- a/src/assets/data/basicInfoTabs.js
+++ b/src/assets/data/basicInfoTabs.js
@@ -1,0 +1,4 @@
+export const basicInfoTabs = [
+  { text: '기본 정보', key: 'basicInfo', content: '기본 정보다아' },
+  { text: '매장 설명', key: 'storeDescription', content: '매장 설명이다아' },
+];

--- a/src/assets/data/storeData.js
+++ b/src/assets/data/storeData.js
@@ -1,0 +1,27 @@
+export const storeData = [
+  {
+    label: '매장명',
+    type: 'text',
+    placeholder: '',
+  },
+  {
+    label: '영업시간',
+    type: 'text',
+    placeholder: '시간',
+  },
+  {
+    label: '매장의 전화번호를 입력해주세요',
+    type: 'text',
+    placeholder: 'ex) 01012345678',
+  },
+  {
+    label: '카테고리',
+    type: 'radio',
+    placeholder: '',
+  },
+  {
+    label: '위치정보',
+    type: 'text',
+    placeholder: '주소를 입력해주세요',
+  },
+];

--- a/src/assets/data/writingTabs.js
+++ b/src/assets/data/writingTabs.js
@@ -1,0 +1,4 @@
+export const writingTabs = [
+  { text: '글쓰기', key: 'writePost', content: '글쓰기다아' },
+  { text: '내가 쓴 글', key: 'myPosts', content: '내가 쓴 글이다아' },
+];

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { COLORS } from '../../styles/theme';
+
+const Button = ({ text, onClickBtn, size, color, disabled, loading }) => {
+  return (
+    <Btn
+      onClick={onClickBtn}
+      size={size}
+      color={color}
+      disabled={disabled || loading}
+      loading={loading}
+    >
+      {loading ? 'Loading...' : text}
+    </Btn>
+  );
+};
+
+Button.propTypes = {
+  text: PropTypes.string.isRequired,
+  onClickBtn: PropTypes.func,
+  size: PropTypes.shape({
+    width: PropTypes.number,
+    height: PropTypes.number,
+    fontSize: PropTypes.number,
+  }),
+  color: PropTypes.string,
+  disabled: PropTypes.bool,
+  loading: PropTypes.bool,
+};
+
+export default Button;
+
+const Btn = styled.button`
+  display: flex;
+  width: 180px;
+  height: 52px;
+  padding: 8px 16px;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  border: none;
+  border-radius: 12px;
+  background: ${COLORS.btn_lightgray};
+  color: ${COLORS.text_btn_darkgray};
+  text-align: center;
+  font-family: 'Pretendard';
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 132%; /* 23.76px */
+  letter-spacing: 0.54px;
+
+  &:hover {
+    background: ${COLORS.btn_lightgray};
+    color: ${COLORS.text_btn_darkgray};
+    background: ${COLORS.coumo_purple};
+    color: ${COLORS.white};
+  }
+`;

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { COLORS } from '../../styles/theme';
 import { Logo } from '../../assets';
+import Button from './Button';
 
 const Head = styled.div`
   width: 100%;
@@ -15,9 +16,6 @@ const Head = styled.div`
   background-color: ${COLORS.white};
   font-family: 'Pretendard';
   font-size: 20px;
-
-  position: absolute;
-  top: 0;
 `;
 
 const HeaderBar = styled.div`
@@ -42,26 +40,11 @@ const StyledLink = styled(Link)`
   text-decoration-line: none;
 `;
 
-const Button = styled.button`
-  display: flex;
-  width: 150px;
-  height: 42px;
-  padding: 8px 16px;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
-  flex-shrink: 0;
-  border-radius: 12px;
-  background: #e3e1e8;
-  border: none;
-  box-sizing: border-box;
-`;
-
 const Header = () => {
   return (
     <Head>
       <HeaderBar>
-        <Link to='/'>
+        <Link to='/home'>
           <Logo />
         </Link>
         <Nav>
@@ -70,7 +53,7 @@ const Header = () => {
           <StyledLink to='/coupon'>쿠폰 관리</StyledLink>
           <StyledLink to='/customer'>고객 데이터 관리</StyledLink>
         </Nav>
-        <Button>임시 버튼</Button>
+        <Button text='로그인/회원가입'></Button>
       </HeaderBar>
     </Head>
   );

--- a/src/components/common/Input.jsx
+++ b/src/components/common/Input.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import styled from 'styled-components';
+import { COLORS } from '../../styles/theme';
+
+const Input = ({ label, type, placeholder }) => {
+  return (
+    <Element>
+      <StyledInputTitle>{label}</StyledInputTitle>
+      <StyledInput type={type} placeholder={placeholder}></StyledInput>
+    </Element>
+  );
+};
+
+export default Input;
+
+const Element = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledInputTitle = styled.div`
+  color: ${COLORS.coumo_purple};
+  font-family: 'Pretendard';
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 132%; /* 31.68px */
+  letter-spacing: 0.72px;
+  padding-bottom: 16px;
+`;
+
+const StyledInput = styled.input`
+  display: flex;
+  width: 344px;
+  height: 42px;
+  padding: 8px 12px;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: ${COLORS.coumo_gray};
+  overflow: hidden;
+  color: ${COLORS.text_gray};
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: 'Pretendard';
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 170%; /* 27.2px */
+
+  &:focus {
+    outline: none;
+  }
+`;

--- a/src/components/common/RadioBtn.jsx
+++ b/src/components/common/RadioBtn.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import styled from 'styled-components';
+import { COLORS } from '../../styles/theme';
+
+const RadioBtn = ({ id, value, name, label }) => {
+  return (
+    <RadioLabel>
+      <RadioInput type='radio' id={id} name={name} value={value} />
+      <RadioSpan for={id}>{label}</RadioSpan>
+    </RadioLabel>
+  );
+};
+
+export default RadioBtn;
+
+const RadioLabel = styled.label`
+  display: flex;
+  align-items: center;
+  width: 136px;
+  height: 48px;
+  padding: 0px 18px;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  border-radius: 4px;
+  background: ${COLORS.coumo_gray};
+`;
+
+const RadioInput = styled.input`
+  vertical-align: middle;
+  appearance: none;
+  border: max(2px, 0.1em) solid gray;
+  border-radius: 50%;
+  width: 1.6em;
+  height: 1.6em;
+  transition: border 0.5s ease-in-out;
+
+  &:checked {
+    border: 0.8em solid ${COLORS.coumo_purple};
+  }
+
+  &:hover {
+    box-shadow: 0 0 0 max(4px, 0.2em) lightgray;
+    cursor: pointer;
+  }
+`;
+
+const RadioSpan = styled.span`
+  overflow: hidden;
+  color: #545252;
+  text-overflow: ellipsis;
+  font-family: 'Pretendard';
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 170%; /* 27.2px */
+`;

--- a/src/components/common/Tab.jsx
+++ b/src/components/common/Tab.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+import { COLORS } from '../../styles/theme';
+
+const Tab = ({ text, onClickTab, isSelected }) => {
+  return (
+    <>
+      <TabDiv onClick={onClickTab} selected={isSelected}>
+        {text}
+      </TabDiv>
+    </>
+  );
+};
+
+export default Tab;
+
+const TabDiv = styled.div`
+  display: flex;
+  width: 204px;
+  height: 29px;
+  padding: 12px 8px;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  border-radius: 16px 16px 0px 0px;
+  background: ${(props) =>
+    props.selected ? COLORS.coumo_purple : COLORS.btn_lightgray};
+  color: ${(props) => (props.selected ? COLORS.white_fff : COLORS.tab_gray)};
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 132%; /* 21.12px */
+  letter-spacing: 0.48px;
+`;

--- a/src/components/common/TabBar.jsx
+++ b/src/components/common/TabBar.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Tab from './Tab';
+import { COLORS } from '../../styles/theme';
+
+const TabBar = ({ tabs }) => {
+  const [selectedTab, setSelectedTab] = useState(tabs[0].key);
+
+  const handleTabClick = (key) => {
+    setSelectedTab(key);
+  };
+
+  return (
+    <>
+      <StyledTab>
+        {tabs.map((tab) => (
+          <Tab
+            key={tab.key}
+            text={tab.text}
+            onClickTab={() => handleTabClick(tab.key)}
+            isSelected={selectedTab === tab.key}
+          />
+        ))}
+      </StyledTab>
+      <Content>{tabs.find((tab) => tab.key === selectedTab)?.content}</Content>
+    </>
+  );
+};
+
+export default TabBar;
+
+const StyledTab = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+const Content = styled.div`
+  width: 440px;
+  height: 400px;
+  background-color: ${COLORS.coumo_lightpurple};
+  color: ${COLORS.tab_gray};
+  font-size: 16px;
+  padding: 20px;
+  box-sizing: border-box;
+  font-weight: 500;
+`;

--- a/src/pages/Shop.jsx
+++ b/src/pages/Shop.jsx
@@ -1,7 +1,20 @@
 import React from 'react';
+import Input from '../components/common/Input';
+import RadioBtn from '../components/common/RadioBtn';
+import TabBar from '../components/common/TabBar';
+import { basicInfoTabs } from '../assets/data/basicInfoTabs';
+import { writingTabs } from '../assets/data/writingTabs';
 
 const Shop = () => {
-  return <div>Shop</div>;
+  return (
+    <>
+      <Input label='매장명' type='text' placeholder='김밥천국' />
+      <TabBar tabs={basicInfoTabs} />
+      <TabBar tabs={writingTabs} />
+      <RadioBtn name='store' label='카페/디저트' />
+      <RadioBtn name='store' label='요식업' />
+    </>
+  );
 };
 
 export default Shop;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -5,7 +5,11 @@ export const COLORS = {
   coumo_gray: '#E9E9E9',
   text_black: '#383D43',
   text_darkgray: '#514D59',
+  text_btn_darkgray: '#5E586A',
   text_gray: '#545252',
   text_lightgray: '#B1B1B1',
+  btn_lightgray: '#E3E1E8;',
+  tab_gray: '#7D7788',
   white: '#FCFCFC',
+  white_fff: '#FFFFFF',
 };


### PR DESCRIPTION
## 📍 작업 내용
공통 컴포넌트 (Button, Input, RadioBtn, Tab, TabBar) 생성

<br/>

## 📍 구현 결과 (선택)
https://github.com/UMC-5th-Kumo/Coumo_Web/assets/102593738/79170018-330b-4b0c-8e92-13d6223f8f14


<br/>

## 📍 기타 사항
- shop 페이지에 구현한 컴포넌트들 보이게 넣어두었습니다.
- 작업에 필요한 색상(theme.js), 데이터(data 폴더 내 파일) 추가하였습니다.
- Tab 전환에 따른 Content는 data set에 임의로 넣어둔 것입니다. 추후에는 컴포넌트 혹은 페이지로 변경할 것입니다.
- RadioBtn의 data는 아직 파일을 별도로 만들지 않고 직접 넣어주는 방식으로 화면에 임시 표현해두었습니다. (그리고 여기서 style을 넣어봤는데, 색칠이 채워지고 지워지는 효과가 난잡하다면 피드백 주시면 감사드리겠습니다!)
- Input에서 영업 시간 및 주소 입력은 우선 비워두고, text 위주의 입력만을 고려하여 구현했습니다.

<br/>
