### PR TITLE
[Feat/#14]: 동네소식 - 내가 쓴 글 보기 페이지

### DIFF
--- a/src/assets/icon/line.svg
+++ b/src/assets/icon/line.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="896" height="4" viewBox="0 0 896 4" fill="none">
+  <path d="M0 2H896" stroke="#D2D2D4" stroke-width="2"/>
+</svg>

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -1,3 +1,4 @@
 export { ReactComponent as Logo } from './icon/Logo.svg';
 export { ReactComponent as Arrow } from './icon/arrow.svg';
 export { ReactComponent as BannerIcon } from './icon/banner-icon.svg';
+export { ReactComponent as Line } from './icon/line.svg';

--- a/src/components/admin/neighborhood/Post.jsx
+++ b/src/components/admin/neighborhood/Post.jsx
@@ -3,22 +3,15 @@ import styled from 'styled-components';
 import { COLORS } from '../../../styles/theme';
 import TagButton from './TagButton';
 
-const Post = () => {
+const Post = ({ data }) => {
   return (
     <Container>
       <Content>
         <TitleBox>
-          <TagButton />
-          <Title>팀메리 1월 신메뉴 출시</Title>
+          <TagButton tag={data.tag} />
+          <Title>{data.title}</Title>
         </TitleBox>
-        <PostContent>
-          2024년 갑진년을 맞이하여 팀메리가 신메뉴를 출시했습니다.
-          <br />
-          이번에는 딸기와 초코로 색다른 맛을 표현해봤어요~
-          <br />
-          달달한 거 좋아하시는 분들께 강추하는 메뉴입니다! :) 어쩌구 저쩌구
-          어쩌구 저쩌구
-        </PostContent>
+        <PostContent>{data.content}</PostContent>
       </Content>
       <Image></Image>
     </Container>

--- a/src/components/admin/neighborhood/TagButton.jsx
+++ b/src/components/admin/neighborhood/TagButton.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import { COLORS } from '../../../styles/theme';
 
-const TagButton = () => {
-  return <Container>신메뉴/신상품</Container>;
+const TagButton = ({ tag }) => {
+  return <Container>{tag}</Container>;
 };
 
 export default TagButton;

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -39,6 +39,7 @@ const Btn = styled.button`
   padding: 8px 16px;
   justify-content: center;
   align-items: center;
+  cursor: pointer;
   gap: 8px;
   flex-shrink: 0;
   border: none;

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -16,6 +16,8 @@ const Head = styled.div`
   background-color: ${COLORS.white};
   font-family: 'Pretendard';
   font-size: 20px;
+  position: absolute;
+  top: 0;
 `;
 
 const HeaderBar = styled.div`
@@ -44,7 +46,7 @@ const Header = () => {
   return (
     <Head>
       <HeaderBar>
-        <Link to='/home'>
+        <Link to='/'>
           <Logo />
         </Link>
         <Nav>

--- a/src/components/common/TabBar.jsx
+++ b/src/components/common/TabBar.jsx
@@ -1,13 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import Tab from './Tab';
-import { COLORS } from '../../styles/theme';
 
-const TabBar = ({ tabs }) => {
-  const [selectedTab, setSelectedTab] = useState(tabs[0].key);
-
+const TabBar = ({ tabs, selected, setSelected }) => {
   const handleTabClick = (key) => {
-    setSelectedTab(key);
+    setSelected(key);
   };
 
   return (
@@ -18,11 +15,10 @@ const TabBar = ({ tabs }) => {
             key={tab.key}
             text={tab.text}
             onClickTab={() => handleTabClick(tab.key)}
-            isSelected={selectedTab === tab.key}
+            isSelected={selected === tab.key}
           />
         ))}
       </StyledTab>
-      <Content>{tabs.find((tab) => tab.key === selectedTab)?.content}</Content>
     </>
   );
 };
@@ -32,15 +28,4 @@ export default TabBar;
 const StyledTab = styled.div`
   display: flex;
   flex-direction: row;
-`;
-
-const Content = styled.div`
-  width: 440px;
-  height: 400px;
-  background-color: ${COLORS.coumo_lightpurple};
-  color: ${COLORS.tab_gray};
-  font-size: 16px;
-  padding: 20px;
-  box-sizing: border-box;
-  font-weight: 500;
 `;

--- a/src/components/common/Title.jsx
+++ b/src/components/common/Title.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from 'styled-components';
+import { COLORS } from '../../styles/theme';
+import { Line } from '../../assets';
+
+const Title = ({ title }) => {
+  return (
+    <Container>
+      <StyledTitle>{title}</StyledTitle>
+      <Line />
+    </Container>
+  );
+};
+
+export default Title;
+
+const Container = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+  margin-bottom: 87px;
+`;
+
+const StyledTitle = styled.h1`
+  color: ${COLORS.coumo_purple};
+  font-size: 32px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 132%;
+  margin: 0;
+`;

--- a/src/pages/Neighborhood.jsx
+++ b/src/pages/Neighborhood.jsx
@@ -1,12 +1,36 @@
-import React from 'react';
-import Post from '../components/admin/neighborhood/Post';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { writingTabs } from '../assets/data/writingTabs';
+import TabBar from '../components/common/TabBar';
+import { COLORS } from '../styles/theme';
+import MyPosts from './neighborhood/MyPosts';
 
 const Neighborhood = () => {
+  const [selected, setSelected] = useState(writingTabs[0].key);
   return (
-    <div>
-      <Post />
-    </div>
+    <Container>
+      <TabBar
+        tabs={writingTabs}
+        selected={selected}
+        setSelected={setSelected}
+      />
+      <Content>{selected === 'myPosts' && <MyPosts />}</Content>
+    </Container>
   );
 };
 
 export default Neighborhood;
+
+const Container = styled.div`
+  box-sizing: border-box;
+  padding: 70px 120px;
+`;
+
+const Content = styled.div`
+  width: 100%;
+  color: ${COLORS.tab_gray};
+  font-size: 16px;
+  padding: 70px 0px;
+  box-sizing: border-box;
+  font-weight: 500;
+`;

--- a/src/pages/neighborhood/MyPosts.jsx
+++ b/src/pages/neighborhood/MyPosts.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import Title from '../../components/common/Title';
+import Post from '../../components/admin/neighborhood/Post';
+import styled from 'styled-components';
+
+const MyPosts = () => {
+  return (
+    <>
+      <Title title='총 13개의 게시글이 있어요!' />
+      <PostContainer>
+        {postDummyData.map((data, index) => {
+          return <Post key={index} data={data} />;
+        })}
+      </PostContainer>
+    </>
+  );
+};
+
+export default MyPosts;
+
+const PostContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+`;
+
+// 임시 더미 데이터
+const postDummyData = [
+  {
+    tag: '신메뉴/신상품',
+    title: '팀메리 1월 신메뉴 출시',
+    content:
+      '2024년 갑진년을 맞이하여 팀메리가 신메뉴를 출시했습니다.\n이번에는 딸기와 초코로 색다른 맛을 표현해봤어요~\n달달한 거 좋아하시는 분들께 강추하는 메뉴입니다! :) 어쩌구 저쩌구 어쩌구 저쩌구',
+    image: '',
+  },
+  {
+    tag: '신메뉴/신상품',
+    title: '팀메리 1월 신메뉴 출시',
+    content:
+      '2024년 갑진년을 맞이하여 팀메리가 신메뉴를 출시했습니다.\n이번에는 딸기와 초코로 색다른 맛을 표현해봤어요~\n달달한 거 좋아하시는 분들께 강추하는 메뉴입니다! :) 어쩌구 저쩌구 어쩌구 저쩌구',
+    image: '',
+  },
+  {
+    tag: '신메뉴/신상품',
+    title: '팀메리 1월 신메뉴 출시',
+    content:
+      '2024년 갑진년을 맞이하여 팀메리가 신메뉴를 출시했습니다.\n이번에는 딸기와 초코로 색다른 맛을 표현해봤어요~\n달달한 거 좋아하시는 분들께 강추하는 메뉴입니다! :) 어쩌구 저쩌구 어쩌구 저쩌구',
+    image: '',
+  },
+  {
+    tag: '신메뉴/신상품',
+    title: '팀메리 1월 신메뉴 출시',
+    content:
+      '2024년 갑진년을 맞이하여 팀메리가 신메뉴를 출시했습니다.\n이번에는 딸기와 초코로 색다른 맛을 표현해봤어요~\n달달한 거 좋아하시는 분들께 강추하는 메뉴입니다! :) 어쩌구 저쩌구 어쩌구 저쩌구',
+    image: '',
+  },
+];


### PR DESCRIPTION
## 📍 작업 내용
동네소식 - 내가 쓴 글 보기 페이지 구현

<br/>

## 📍 구현 결과 (선택)
<img width="1433" alt="스크린샷 2024-01-17 오후 3 43 00" src="https://github.com/UMC-5th-Kumo/Coumo_Web/assets/121474189/a3fe6d30-89ed-447b-baf8-b231d93bc591">

<br/>

## 📍 기타 사항
- 헤더 위치 수정
- post는 더미데이터 넣어둔 상태
- tabBar 를 클릭했을 때 setSeledted는 tabBar를 사용하는 해당 컴포넌트에서 props로 넘겨주도록 하고, 바깥에서 selected 값에 따라 렌더링을 달리하도록 변경했습니다!
<img width="491" alt="스크린샷 2024-01-17 오후 3 45 35" src="https://github.com/UMC-5th-Kumo/Coumo_Web/assets/121474189/b1b028f2-5e01-49cb-8e68-3ee3ecef5775">

<br/>
