### PR TITLE
[Feat/#22]: 매장관리 - 기본 정보 페이지

### DIFF
--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -5,7 +5,6 @@ import { COLORS } from '../../styles/theme';
 const Button = ({
   text,
   onClickBtn,
-  size,
   color = COLORS.btn_lightgray,
   disabled,
   loading,
@@ -27,13 +26,11 @@ export default Button;
 
 export const Btn = styled.button`
   display: flex;
-  width: 180px;
   height: 52px;
-  padding: 8px 16px;
+  padding: 8px 28px;
   justify-content: center;
   align-items: center;
   cursor: pointer;
-  gap: 8px;
   flex-shrink: 0;
   border: none;
   border-radius: 12px;

--- a/src/pages/coupon/UIServiceForm.jsx
+++ b/src/pages/coupon/UIServiceForm.jsx
@@ -59,28 +59,36 @@ const UIServiceForm = () => {
         type='text'
         placeholder='쿠폰 타이틀을 입력해주세요.'
         value={inputs.couponTitle}
-        onChange={(e) => setInputs({ ...inputs, couponTitle: e.target.value })}
+        onChange={(e) =>
+          setInputs((prev) => ({ ...prev, couponTitle: e.target.value }))
+        }
       />
       <Input
         label='연락처를 입력해주세요.'
         type='text'
-        placeholder='ex) 01012345678'
+        placeholder='ex) 010-1234-5678'
         value={inputs.number}
-        onChange={(e) => setInputs({ ...inputs, number: e.target.value })}
+        onChange={(e) =>
+          setInputs((prev) => ({ ...prev, number: e.target.value }))
+        }
       />
       <Input
         label='이메일 주소를 입력해주세요.'
         type='text'
         placeholder='a12345678@naver.com'
         value={inputs.email}
-        onChange={(e) => setInputs({ ...inputs, email: e.target.value })}
+        onChange={(e) =>
+          setInputs((prev) => ({ ...prev, email: e.target.value }))
+        }
       />
       <Input
-        label='사업자 주소를 입력해주세요.'
+        label='매장 주소를 입력해주세요.'
         type='text'
-        placeholder='a12345678@naver.com'
+        placeholder='서울시 용산구 청파동 777-777'
         value={inputs.address}
-        onChange={(e) => setInputs({ ...inputs, address: e.target.value })}
+        onChange={(e) =>
+          setInputs((prev) => ({ ...prev, address: e.target.value }))
+        }
       />
       <Category category={category} setCategory={setCategory} />
       <Description>

--- a/src/pages/shop/BasicInfo.jsx
+++ b/src/pages/shop/BasicInfo.jsx
@@ -1,7 +1,92 @@
-import React from 'react';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Input from '../../components/common/Input';
+import { COLORS } from '../../styles/theme';
+import Category from '../../components/admin/coupon/Category';
+import Button from '../../components/common/Button';
 
 const BasicInfo = () => {
-  return <div>BasicInfo</div>;
+  const [category, setCategory] = useState('cafe');
+  const [inputs, setInputs] = useState({
+    storeName: '',
+    workingHours: '',
+    number: '',
+    address: '',
+  });
+
+  const onSubmit = () => {
+    // 서버 요청 코드
+  };
+
+  return (
+    <Content>
+      <Input
+        label='매장명'
+        type='text'
+        placeholder='매장명을 입력해주세요.'
+        value={inputs.storeName}
+        onChange={(e) =>
+          setInputs((prev) => ({ ...prev, storeName: e.target.value }))
+        }
+      />
+      <Input
+        label='영업시간'
+        type='text'
+        placeholder='임시'
+        value={inputs.workingHours}
+        onChange={(e) =>
+          setInputs((prev) => ({ ...prev, workingHours: e.target.value }))
+        }
+      />
+      <Input
+        label='매장의 전화번호를 입력해주세요.'
+        type='text'
+        placeholder='ex) 010-1234-5678'
+        value={inputs.number}
+        onChange={(e) =>
+          setInputs((prev) => ({ ...prev, number: e.target.value }))
+        }
+      />
+      <Category category={category} setCategory={setCategory} />
+      <Input
+        label='위치정보'
+        type='text'
+        placeholder='주소를 입력해주세요.'
+        value={inputs.address}
+        onChange={(e) =>
+          setInputs((prev) => ({ ...prev, address: e.target.value }))
+        }
+      />
+      <BtnContainer>
+        <Button text='취소하기' />
+        <Button
+          text='저장하기'
+          color={COLORS.coumo_purple}
+          onClickBtn={onSubmit}
+        />
+      </BtnContainer>
+    </Content>
+  );
 };
 
 export default BasicInfo;
+
+const Content = styled.div`
+  width: 100%;
+  height: auto;
+  color: ${COLORS.tab_gray};
+  font-size: 16px;
+  box-sizing: border-box;
+  font-weight: 500;
+  position: relative;
+
+  display: flex;
+  flex-direction: column;
+  gap: 88px;
+`;
+
+const BtnContainer = styled.div`
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+`;


### PR DESCRIPTION
## 📍 작업 내용
매장관리 - 기본 정보 페이지 구현

<br/>

## 📍 구현 결과 (선택)
<img width="1440" alt="스크린샷 2024-01-18 오후 3 09 31" src="https://github.com/UMC-5th-Kumo/Coumo_Web/assets/121474189/9e89b3f0-ae5b-4155-a1e4-aaff2198241b">
<img width="1440" alt="스크린샷 2024-01-18 오후 3 09 43" src="https://github.com/UMC-5th-Kumo/Coumo_Web/assets/121474189/d753cc92-d7a5-4641-bcfa-4ac0062f5445">


<br/>

## 📍 기타 사항
- 폼 작성 페이지와 거의 똑같습니다!
- 버튼 컴포넌트에 전달하는 text에 맞게 크기가 알아서 조정되도록 수정했는데 merge할 때 충돌나면 제 코드로 합쳐주시면 됩니다!!

<br/>
