### PR TITLE
[Feat/#50]: 고객 데이터 방문자수 컴포넌트

### DIFF
--- a/src/assets/icon/arrow-down.svg
+++ b/src/assets/icon/arrow-down.svg
@@ -1,0 +1,11 @@
+<svg width="40" height="45" viewBox="0 0 51 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Frame 1321317650">
+<path id="arrow_upward_alt" d="M29.1667 3.75L29.1667 40.4833L42.3667 27.2833L47.5 32.4167L25.5 54.4167L3.5 32.4167L8.63333 27.2833L21.8333 40.4833L21.8333 3.75L29.1667 3.75Z" fill="url(#paint0_linear_250_1349)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_250_1349" x1="25.5" y1="57.167" x2="25.5" y2="6.66699" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6B1DFF"/>
+<stop offset="1" stop-color="#7C43E8" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/assets/icon/arrow-up.svg
+++ b/src/assets/icon/arrow-up.svg
@@ -1,0 +1,11 @@
+<svg width="40" height="45" viewBox="0 0 50 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Frame 1321317650">
+<path id="arrow_upward_alt" d="M21.3333 54.4167V17.6833L8.13333 30.8833L3 25.75L25 3.75L47 25.75L41.8667 30.8833L28.6667 17.6833V54.4167H21.3333Z" fill="url(#paint0_linear_250_1340)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_250_1340" x1="25" y1="1" x2="25" y2="51.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6B1DFF"/>
+<stop offset="1" stop-color="#7C43E8" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -12,3 +12,5 @@ export { ReactComponent as LogoCongratulate } from './icon/LogoCongratulate.svg'
 export { ReactComponent as UIArticle } from './icon/UIArticle.svg';
 export { ReactComponent as CouponYellow } from './icon/CouponYellow.svg';
 export { ReactComponent as CouponPeach } from './icon/CouponPeach.svg';
+export { ReactComponent as ArrowUp } from './icon/arrow-up.svg';
+export { ReactComponent as ArrowDown } from './icon/arrow-down.svg';

--- a/src/components/admin/customer/VisitCount.jsx
+++ b/src/components/admin/customer/VisitCount.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import styled from 'styled-components';
+import { COLORS } from '../../../styles/theme';
+import { ArrowDown, ArrowUp } from '../../../assets';
+
+function VisitCount({ type }) {
+  return (
+    <Container>
+      {type === 'max' ? <ArrowUp /> : <ArrowDown />}
+      <Content>
+        <span>
+          방문자 수가 가장 <strong>{type === 'max' ? '많은' : '적은'}</strong>{' '}
+          요일은?
+        </span>
+        <h5>금요일 (128명)</h5>
+      </Content>
+    </Container>
+  );
+}
+
+export default VisitCount;
+
+const Container = styled.div`
+  width: 210px;
+  height: 45px;
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 8px;
+
+  & span {
+    font-size: 12.8px;
+    color: #7d7788;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 100%; /* 16px */
+    letter-spacing: 0.16px;
+
+    & strong {
+      color: ${COLORS.coumo_purple};
+    }
+  }
+
+  & h5 {
+    margin: 0;
+    font-size: 19px;
+    color: ${COLORS.coumo_purple};
+  }
+`;

--- a/src/components/admin/customer/charts/BarChart.jsx
+++ b/src/components/admin/customer/charts/BarChart.jsx
@@ -33,8 +33,8 @@ function BarChart() {
 export default BarChart;
 
 const Container = styled.div`
-  width: 550px;
-  height: 300px;
+  width: 100%;
+  height: 100%;
 `;
 
 const data = {
@@ -51,7 +51,7 @@ const data = {
         { x: '일', y: 40 },
       ],
       backgroundColor: ({ chart: { ctx } }) => {
-        const bg = ctx.createLinearGradient(0, 50, 0, 300);
+        const bg = ctx.createLinearGradient(0, 50, 0, 350);
         bg.addColorStop(0, '#9d9d9d');
         bg.addColorStop(1, '#ffffff');
         return bg;

--- a/src/components/admin/customer/charts/DoughnutChart.jsx
+++ b/src/components/admin/customer/charts/DoughnutChart.jsx
@@ -31,7 +31,7 @@ const options = {
       },
     },
   },
-  cutout: 75,
+  cutout: 60,
 };
 
 function DoughnutChart() {
@@ -45,6 +45,6 @@ function DoughnutChart() {
 export default DoughnutChart;
 
 const Container = styled.div`
-  width: 250px;
-  height: 250px;
+  width: 200px;
+  height: 200px;
 `;

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -18,7 +18,7 @@ const Header = () => {
           <StyledLink to='/shop/basicInfo'>매장 관리</StyledLink>
           <StyledLink to='/neighborhood/writePost'>동네 소식</StyledLink>
           <StyledLink to='/coupon/addCoupon'>쿠폰 관리</StyledLink>
-          <StyledLink to='/customer'>고객 데이터 관리</StyledLink>
+          <StyledLink to='/customer/manage'>고객 데이터 관리</StyledLink>
         </Nav>
         <Button
           text='로그인/회원가입'

--- a/src/pages/customer/visitAnalysis/DailyVisit.jsx
+++ b/src/pages/customer/visitAnalysis/DailyVisit.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
 import BarChart from '../../../components/admin/customer/charts/BarChart';
+import VisitCount from '../../../components/admin/customer/VisitCount';
 
 function DailyVisit() {
   return (
     <Container>
-      <VisitData></VisitData>
+      <VisitData>
+        <VisitCount type='max' />
+        <VisitCount type='min' />
+      </VisitData>
       <ChartContainer>
         <BarChart />
       </ChartContainer>
@@ -24,6 +28,8 @@ const Container = styled.div`
 const VisitData = styled.div`
   width: 100%;
   height: 60px;
+  display: flex;
+  gap: 120px;
 `;
 
 const ChartContainer = styled.div`

--- a/src/pages/customer/visitAnalysis/DemographicVisit.jsx
+++ b/src/pages/customer/visitAnalysis/DemographicVisit.jsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import Calendar from '../../../components/admin/customer/Calendar';
 import DoughnutChart from '../../../components/admin/customer/charts/DoughnutChart';
 import BarChart from '../../../components/admin/customer/charts/BarChart';
+import VisitCount from '../../../components/admin/customer/VisitCount';
 
 function DemographicVisit() {
   const [selected, setSelected] = useState(visitTabs[0].key);
@@ -18,9 +19,15 @@ function DemographicVisit() {
         />
         <Calendar />
       </Header>
+      <VisitData>
+        <VisitCount type='max' />
+        <VisitCount type='min' />
+      </VisitData>
       <ChartContainer>
         <DoughnutChart />
-        <BarChart />
+        <Bar>
+          <BarChart />
+        </Bar>
       </ChartContainer>
     </>
   );
@@ -34,10 +41,23 @@ const Header = styled.div`
   justify-content: space-between;
 `;
 
+const VisitData = styled.div`
+  width: 100%;
+  height: 60px;
+  display: flex;
+  gap: 120px;
+  margin: 28px 0px 19px 0px;
+`;
+
 const ChartContainer = styled.div`
   width: 100%;
   height: 300px;
   display: flex;
   justify-content: space-around;
   align-items: center;
+`;
+
+const Bar = styled.div`
+  width: 600px;
+  height: 320px;
 `;

--- a/src/pages/customer/visitAnalysis/TimeVisit.jsx
+++ b/src/pages/customer/visitAnalysis/TimeVisit.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
 import LineChart from '../../../components/admin/customer/charts/LineChart';
+import VisitCount from '../../../components/admin/customer/VisitCount';
 
 function TimeVisit() {
   return (
     <Container>
-      <VisitData></VisitData>
+      <VisitData>
+        <VisitCount type='max' />
+        <VisitCount type='min' />
+      </VisitData>
       <ChartContainer>
         <LineChart />
       </ChartContainer>
@@ -24,6 +28,8 @@ const Container = styled.div`
 const VisitData = styled.div`
   width: 100%;
   height: 60px;
+  display: flex;
+  gap: 120px;
 `;
 
 const ChartContainer = styled.div`


### PR DESCRIPTION
## 📍 작업 내용
- 고객 데이터 방문자수 컴포넌트 생성
- 차트 배치 일부 수정

<br/>

## 📍 구현 결과 (선택)
<img width="1040" alt="스크린샷 2024-01-28 오전 12 01 08" src="https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/2f6fc840-5f23-4aa5-89d5-05a709612a33">

<br/>

## 📍 기타 사항
지금은 다 같은 컴포넌트로 넣어뒀는데 추후에는 페이지별로 props 넘겨서 처리할게요!

<br/>
