### PR TITLE
[Style/#63]: 쿠폰 도장 개수 수정

### DIFF
--- a/src/components/admin/coupon/StampCount.jsx
+++ b/src/components/admin/coupon/StampCount.jsx
@@ -6,27 +6,21 @@ function StampCount({ stamp_max, setMax }) {
   return (
     <Container>
       <RadioButton
-        id='7'
-        label='7개'
-        selected={stamp_max === '7'}
-        onChange={setMax}
-      />
-      <RadioButton
         id='8'
         label='8개'
         selected={stamp_max === '8'}
         onChange={setMax}
       />
       <RadioButton
-        id='9'
-        label='9개'
-        selected={stamp_max === '9'}
-        onChange={setMax}
-      />
-      <RadioButton
         id='10'
         label='10개'
         selected={stamp_max === '10'}
+        onChange={setMax}
+      />
+      <RadioButton
+        id='12'
+        label='12개'
+        selected={stamp_max === '12'}
         onChange={setMax}
       />
     </Container>

--- a/src/pages/coupon/AddCoupon.jsx
+++ b/src/pages/coupon/AddCoupon.jsx
@@ -13,7 +13,7 @@ const AddCoupon = () => {
   const [coupon, setCoupon] = useState({
     storeName: '',
     color: '#7C43E8',
-    stamp_max: '7',
+    stamp_max: '8',
     stamp_image: '',
     stamp_id: '1',
   });
@@ -80,7 +80,7 @@ const AddCoupon = () => {
               </CouponTitle>
               <StampBox num={coupon.stamp_max}>
                 {stamps.map((s, i) => {
-                  return <Stamp key={i} />;
+                  return <Stamp key={i} num={coupon.stamp_max} />;
                 })}
               </StampBox>
             </CouponExample>
@@ -127,7 +127,7 @@ const TitleBar = styled.div`
     font-size: 14px;
     font-style: normal;
     font-weight: 400;
-    line-height: 132%; /* 26.4px */
+    line-height: 132%;
   }
 `;
 
@@ -200,17 +200,17 @@ const StepContainer = styled.div`
 `;
 
 const StampBox = styled.div`
-  width: ${(props) => (props.num > 8 ? '400px' : '368px')};
+  width: ${(props) => (props.num > 8 ? '450px' : '368px')};
   height: 138px;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 10px 15px;
+  gap: ${(props) => (props.num > 10 ? '5px 15px' : '10px 15px')};
 `;
 
 const Stamp = styled.div`
-  width: 65px;
-  height: 65px;
+  width: ${(props) => (props.num > 10 ? '58px' : '65px')};
+  height: ${(props) => (props.num > 10 ? '58px' : '65px')};
   border-radius: 50%;
   background: #f6f6f6;
 `;


### PR DESCRIPTION
## 📍 작업 내용
쿠폰 도장 개수 수정 -> 8, 10, 12개로 간소화

<br/>

## 📍 구현 결과 (선택)
![화면 기록 2024-01-30 오전 12 48 02](https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/001146a7-fd93-456e-ae26-1a601ba9be28)

<br/>

## 📍 기타 사항

<br/>
