### PR TITLE
[Redux/#67]: 유저 데이터 redux 연동

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
   "plugins": ["react", "prettier"],
   "rules": {
     "prettier/prettier": ["error", { "endOfLine": "auto" }],
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "no-useless-catch": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-redux": "^9.1.0",
         "react-router-dom": "^6.21.2",
         "react-scripts": "5.0.1",
+        "redux-persist": "^6.0.0",
         "styled-components": "^6.1.8",
         "web-vitals": "^2.1.4"
       },
@@ -16147,6 +16148,14 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-redux": "^9.1.0",
     "react-router-dom": "^6.21.2",
     "react-scripts": "5.0.1",
+    "redux-persist": "^6.0.0",
     "styled-components": "^6.1.8",
     "web-vitals": "^2.1.4"
   },

--- a/src/components/login/LoginBox.jsx
+++ b/src/components/login/LoginBox.jsx
@@ -1,18 +1,42 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Btn } from '../common/Button';
 import { COLORS } from '../../styles/theme';
 import { LoginId, LoginPw, LoginSave, LoginSaveCheck } from '../../assets';
 import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { setUser } from '../../redux/slices/userSlice';
 
 const LoginBox = () => {
   const [id, setId] = useState('');
   const [pw, setPw] = useState('');
   const [save, setSave] = useState(false);
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
   const isLoginEnabled = () => {
     return id.trim() !== '' && pw.trim() !== '';
+  };
+
+  // 마운트 되었을 때 이전에 저장된 id, pw 있는지 확인
+  // useEffect(() => {}, []);
+
+  const handleLoginClick = () => {
+    // 서버 요청 후 예상 데이터
+    const userData = {
+      name: '이름',
+      email: 'admin123@gmail.com',
+      phone: '010-1234-1234',
+      id: 'admin123',
+      pw: 'admin123',
+      token: '1',
+    };
+
+    // 리덕스에 저장
+    dispatch(setUser(userData));
+
+    // 관리자 페이지로 redirect -> 일단 마이페이지로 랜딩
+    navigate('/mypage');
   };
 
   const handleSaveClick = () => {
@@ -46,9 +70,9 @@ const LoginBox = () => {
         <Line>
           <>
             {save ? (
-              <LoginSaveCheck onClick={handleUnsaveClick} />
+              <LoginSaveCheck onClick={handleSaveClick} />
             ) : (
-              <LoginSave onClick={handleSaveClick} />
+              <LoginSave onClick={handleUnsaveClick} />
             )}
           </>
           <Text>로그인 정보 저장하기</Text>
@@ -56,9 +80,7 @@ const LoginBox = () => {
       </Group>
       <LoginBtn
         text='로그인하기'
-        onClick={() => {
-          navigate('/');
-        }}
+        onClick={handleLoginClick}
         disabled={!isLoginEnabled()}
       />
       <Text>

--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,16 @@ import App from './App';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import './styles/index.css';
-import { store } from './redux/store';
+import { persistor, store } from './redux/store';
+import { PersistGate } from 'redux-persist/integration/react';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <Provider store={store}>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <PersistGate loading={null} persistor={persistor}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </PersistGate>
   </Provider>
 );

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -1,5 +1,8 @@
 import { combineReducers } from '@reduxjs/toolkit';
+import userReducer from './slices/userSlice';
 
-const rootReducer = combineReducers({});
+const rootReducer = combineReducers({
+  user: userReducer,
+});
 
 export default rootReducer;

--- a/src/redux/slices/userSlice.js
+++ b/src/redux/slices/userSlice.js
@@ -1,0 +1,31 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  name: '',
+  email: '',
+  phone: '',
+  id: '',
+  pw: '',
+  token: '',
+};
+
+const userSlice = createSlice({
+  name: 'user',
+  initialState: initialState,
+  reducers: {
+    setUser: (state, action) => {
+      state.name = action.payload.name;
+      state.email = action.payload.email;
+      state.phone = action.payload.phone;
+      state.id = action.payload.id;
+      state.pw = action.payload.pw;
+      state.token = action.payload.token;
+    },
+  },
+});
+
+// actions
+export const { setUser } = userSlice.actions;
+
+// reducer export
+export default userSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,5 +1,22 @@
 import { configureStore } from '@reduxjs/toolkit';
 import rootReducer from './reducer';
+import storage from 'redux-persist/lib/storage';
+import { persistReducer, persistStore } from 'redux-persist';
+
+// redux-persist
+const persistConfig = {
+  key: 'root',
+  storage: storage,
+};
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
 
 // redux-thunk 내장, redux-devtools 자동 연동
-export const store = configureStore({ reducer: rootReducer });
+export const store = configureStore({
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({ serializableCheck: false }),
+});
+
+// persistor
+export const persistor = persistStore(store);


### PR DESCRIPTION
## 📍 작업 내용
유저 데이터 redux 연동

<br/>

## 📍 구현 결과 (선택)
구현한 기능이 보이는 스크린샷을 업로드해주세요.

<br/>

## 📍 기타 사항
- 임의로 userData 넣어두고 로그인 버튼 클릭 시 redux에 저장되고 -> 마이페이지로 navigate 되는 것 까지만 구현한 상태 (서버에저 유저 정보 받아서 연결만 하면 되도록 해두었어요)
- redux-persist도 연동해서 유저 정보는 계속 유지되게끔 해놓았습니다!
- 헤더 구분, 마이페이지 데이터 업데이트는 추후에 할 예정

<br/>
