### PR TITLE
[Feat/#72]: 헤더 구분, 마이페이지

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
   "plugins": ["react", "prettier"],
   "rules": {
     "prettier/prettier": ["error", { "endOfLine": "auto" }],
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "no-useless-catch": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-redux": "^9.1.0",
         "react-router-dom": "^6.21.2",
         "react-scripts": "5.0.1",
+        "redux-persist": "^6.0.0",
         "styled-components": "^6.1.8",
         "web-vitals": "^2.1.4"
       },
@@ -16147,6 +16148,14 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-redux": "^9.1.0",
     "react-router-dom": "^6.21.2",
     "react-scripts": "5.0.1",
+    "redux-persist": "^6.0.0",
     "styled-components": "^6.1.8",
     "web-vitals": "^2.1.4"
   },

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -4,9 +4,11 @@ import styled from 'styled-components';
 import { COLORS } from '../../styles/theme';
 import { Logo } from '../../assets';
 import Button from './Button';
+import { useSelector } from 'react-redux';
 
 const Header = () => {
   const navigate = useNavigate();
+  const { name, token } = useSelector((state) => state.user);
 
   return (
     <Head>
@@ -14,18 +16,36 @@ const Header = () => {
         <Link to='/'>
           <Logo />
         </Link>
-        <Nav>
-          <StyledLink to='/shop/basicInfo'>매장 관리</StyledLink>
-          <StyledLink to='/neighborhood/writePost'>동네 소식</StyledLink>
-          <StyledLink to='/coupon/addCoupon'>쿠폰 관리</StyledLink>
-          <StyledLink to='/customer/manage'>고객 데이터 관리</StyledLink>
-        </Nav>
-        <Button
-          text='로그인/회원가입'
-          onClickBtn={() => {
-            navigate('/login');
-          }}
-        ></Button>
+        {token ? (
+          <Nav>
+            <StyledLink to='/shop/basicInfo'>매장 관리</StyledLink>
+            <StyledLink to='/neighborhood/writePost'>동네 소식</StyledLink>
+            <StyledLink to='/coupon/addCoupon'>쿠폰 관리</StyledLink>
+            <StyledLink to='/customer/manage'>고객 데이터 관리</StyledLink>
+          </Nav>
+        ) : (
+          <Nav>
+            <StyledLink to='/'>매장 관리</StyledLink>
+            <StyledLink to='/'>동네 소식</StyledLink>
+            <StyledLink to='/'>쿠폰 관리</StyledLink>
+            <StyledLink to='/'>고객 데이터 관리</StyledLink>
+          </Nav>
+        )}
+        {token ? (
+          <Button
+            text={`${name} 사장님`}
+            onClickBtn={() => {
+              navigate('/mypage');
+            }}
+          ></Button>
+        ) : (
+          <Button
+            text='로그인/회원가입'
+            onClickBtn={() => {
+              navigate('/login');
+            }}
+          ></Button>
+        )}
       </HeaderBar>
     </Head>
   );

--- a/src/components/login/LoginBox.jsx
+++ b/src/components/login/LoginBox.jsx
@@ -1,18 +1,42 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Btn } from '../common/Button';
 import { COLORS } from '../../styles/theme';
 import { LoginId, LoginPw, LoginSave, LoginSaveCheck } from '../../assets';
 import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { setUser } from '../../redux/slices/userSlice';
 
 const LoginBox = () => {
   const [id, setId] = useState('');
   const [pw, setPw] = useState('');
   const [save, setSave] = useState(false);
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
   const isLoginEnabled = () => {
     return id.trim() !== '' && pw.trim() !== '';
+  };
+
+  // 마운트 되었을 때 이전에 저장된 id, pw 있는지 확인
+  // useEffect(() => {}, []);
+
+  const handleLoginClick = () => {
+    // 서버 요청 후 예상 데이터
+    const userData = {
+      name: '이름',
+      email: 'admin123@gmail.com',
+      phone: '010-1234-1234',
+      id: 'admin123',
+      pw: 'admin123',
+      token: '1',
+    };
+
+    // 리덕스에 저장
+    dispatch(setUser(userData));
+
+    // 관리자 페이지로 redirect -> 일단 마이페이지로 랜딩
+    navigate('/mypage');
   };
 
   const handleSaveClick = () => {
@@ -46,9 +70,9 @@ const LoginBox = () => {
         <Line>
           <>
             {save ? (
-              <LoginSaveCheck onClick={handleUnsaveClick} />
+              <LoginSaveCheck onClick={handleSaveClick} />
             ) : (
-              <LoginSave onClick={handleSaveClick} />
+              <LoginSave onClick={handleUnsaveClick} />
             )}
           </>
           <Text>로그인 정보 저장하기</Text>
@@ -56,9 +80,7 @@ const LoginBox = () => {
       </Group>
       <LoginBtn
         text='로그인하기'
-        onClick={() => {
-          navigate('/');
-        }}
+        onClick={handleLoginClick}
         disabled={!isLoginEnabled()}
       />
       <Text>

--- a/src/components/login/LoginBox.jsx
+++ b/src/components/login/LoginBox.jsx
@@ -24,7 +24,7 @@ const LoginBox = () => {
   const handleLoginClick = () => {
     // 서버 요청 후 예상 데이터
     const userData = {
-      name: '이름',
+      name: '강수빈',
       email: 'admin123@gmail.com',
       phone: '010-1234-1234',
       id: 'admin123',

--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,16 @@ import App from './App';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import './styles/index.css';
-import { store } from './redux/store';
+import { persistor, store } from './redux/store';
+import { PersistGate } from 'redux-persist/integration/react';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <Provider store={store}>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <PersistGate loading={null} persistor={persistor}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </PersistGate>
   </Provider>
 );

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -3,13 +3,15 @@ import styled from 'styled-components';
 import { COLORS } from '../styles/theme';
 import Title from '../components/common/Title';
 import { CallIcon, DetailArrow, Line } from '../assets';
+import { useSelector } from 'react-redux';
 
 function MyPage() {
+  const { name, id, email, phone } = useSelector((state) => state.user);
   return (
     <Container>
       <Tab>마이페이지</Tab>
       <TitleBox>
-        <Title title='안녕하세요, 김다빈님!' size={22} />
+        <Title title={`안녕하세요, ${name}님!`} size={22} />
         <Line />
       </TitleBox>
       <Content>
@@ -21,19 +23,19 @@ function MyPage() {
           <InfoContent>
             <InfoLine>
               <h5>이름</h5>
-              <span>김다빈</span>
+              <span>{name}</span>
             </InfoLine>
             <InfoLine>
               <h5>아이디</h5>
-              <span>ddd12345</span>
+              <span>{id}</span>
             </InfoLine>
             <InfoLine>
               <h5>이메일</h5>
-              <span>abc123@gmail.com</span>
+              <span>{email}</span>
             </InfoLine>
             <InfoLine>
               <h5>전화번호</h5>
-              <span>010-2415-1758</span>
+              <span>{phone}</span>
             </InfoLine>
           </InfoContent>
         </Profile>

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -1,5 +1,8 @@
 import { combineReducers } from '@reduxjs/toolkit';
+import userReducer from './slices/userSlice';
 
-const rootReducer = combineReducers({});
+const rootReducer = combineReducers({
+  user: userReducer,
+});
 
 export default rootReducer;

--- a/src/redux/slices/userSlice.js
+++ b/src/redux/slices/userSlice.js
@@ -1,0 +1,31 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  name: '',
+  email: '',
+  phone: '',
+  id: '',
+  pw: '',
+  token: '',
+};
+
+const userSlice = createSlice({
+  name: 'user',
+  initialState: initialState,
+  reducers: {
+    setUser: (state, action) => {
+      state.name = action.payload.name;
+      state.email = action.payload.email;
+      state.phone = action.payload.phone;
+      state.id = action.payload.id;
+      state.pw = action.payload.pw;
+      state.token = action.payload.token;
+    },
+  },
+});
+
+// actions
+export const { setUser } = userSlice.actions;
+
+// reducer export
+export default userSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,5 +1,22 @@
 import { configureStore } from '@reduxjs/toolkit';
 import rootReducer from './reducer';
+import storage from 'redux-persist/lib/storage';
+import { persistReducer, persistStore } from 'redux-persist';
+
+// redux-persist
+const persistConfig = {
+  key: 'root',
+  storage: storage,
+};
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
 
 // redux-thunk 내장, redux-devtools 자동 연동
-export const store = configureStore({ reducer: rootReducer });
+export const store = configureStore({
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({ serializableCheck: false }),
+});
+
+// persistor
+export const persistor = persistStore(store);


### PR DESCRIPTION
## 📍 작업 내용
- 로그인 전 후 헤더 구분 (로그인 전에는 각 페이지로 이동 안되게만 해놓은 상황)
- 마이페이지 데이터 렌더링 (로그인한 유저 데이터로)
- 로그인 후 버튼 사장님 성함으로 변경

<br/>

## 📍 구현 결과 (선택)
![화면 기록 2024-01-30 오후 10 30 35](https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/15c20e62-9a73-4612-b2a6-f8edf38a6145)


<br/>

## 📍 기타 사항
- 추후에 새로운 헤더 만들어지면 그 헤더로 변경해서 처리할게요!

<br/>
