### PR TITLE
[Feat/#68] 아이디, 비밀번호 찾기 페이지

### DIFF
--- a/src/components/common/FindForm.jsx
+++ b/src/components/common/FindForm.jsx
@@ -89,7 +89,7 @@ const FindForm = ({ title, idLabel, serverEndpoint, postData }) => {
               onChange={onChangeNumber}
               width='331px'
             />
-            <NewButton>중복 확인하기</NewButton>
+            <NewButton>인증 확인</NewButton>
           </Row>
         </div>
         <JoinBtn onClick={onSubmit} disabled={!isFindEnabled()}>

--- a/src/components/common/FindForm.jsx
+++ b/src/components/common/FindForm.jsx
@@ -1,0 +1,176 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import InputJoin from './InputJoin';
+import { COLORS } from '../../styles/theme';
+import { Btn } from './Button';
+
+const FindForm = ({ title, idLabel, serverEndpoint, postData }) => {
+  const navigate = useNavigate();
+  const [id, setId] = useState('');
+  const [phone, setPhone] = useState('');
+  const [number, setNumber] = useState('');
+
+  const onChangeId = (e) => {
+    setId(e.target.value);
+  };
+
+  const onChangePhone = (e) => {
+    setPhone(e.target.value);
+  };
+
+  const onChangeNumber = (e) => {
+    setNumber(e.target.value);
+  };
+
+  const isFindEnabled = () => {
+    return id && phone && number;
+  };
+
+  const onCertified = (e) => {
+    e.preventDefault();
+  };
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    if (isFindEnabled()) {
+      console.log('Post Data:', {
+        [postData]: id,
+        phone: phone,
+      });
+
+      try {
+        const response = await axios.post(serverEndpoint, {
+          [postData]: id,
+          phone: phone,
+        });
+
+        if (response.data.isSuccess) {
+          navigate('/login');
+        } else {
+          console.error(response.data.message);
+        }
+      } catch (error) {
+        console.error('error:', error.message);
+      }
+    }
+  };
+
+  return (
+    <Container>
+      <Box>
+        <Title>{title}</Title>
+        <div>
+          <InputJoin
+            label={idLabel}
+            value={id}
+            onChange={onChangeId}
+            width='510px'
+          />
+        </div>
+        <div>
+          <Row>
+            <InputJoin
+              label='휴대전화 번호'
+              placeholder='- 없이'
+              value={phone}
+              onChange={onChangePhone}
+              width='331px'
+            />
+            <NewButton onClick={onCertified}>인증받기</NewButton>
+          </Row>
+        </div>
+        <div>
+          <Row>
+            <InputJoin
+              label='인증번호'
+              value={number}
+              onChange={onChangeNumber}
+              width='331px'
+            />
+            <NewButton>중복 확인하기</NewButton>
+          </Row>
+        </div>
+        <JoinBtn onClick={onSubmit} disabled={!isFindEnabled()}>
+          확인
+        </JoinBtn>
+      </Box>
+    </Container>
+  );
+};
+
+export default FindForm;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  margin-top: 100px;
+`;
+
+const Box = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 15px;
+`;
+
+const Title = styled.div`
+  width: 890px;
+  color: #333;
+  text-align: center;
+  font-size: 36px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 100%;
+  margin-bottom: 45px;
+`;
+
+const JoinBtn = styled.button`
+  display: flex;
+  width: 337px;
+  height: 64px;
+  padding: 14px 10px;
+  justify-content: center;
+  align-items: center;
+  border: none;
+  border-radius: 8px;
+  background: ${COLORS.coumo_purple};
+  color: ${COLORS.white};
+  text-align: center;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 700;
+  margin-top: 60px;
+
+  &:disabled {
+    background: ${COLORS.btn_lightgray};
+    color: ${COLORS.text_btn_darkgray};
+  }
+`;
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+const NewButton = styled(Btn)`
+  display: flex;
+  width: 170px;
+  height: 48px;
+  padding: 9.6px 14.4px;
+  margin-top: 25px;
+  margin-left: 10px;
+  border-radius: 49px;
+  background-color: ${COLORS.coumo_purple};
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 170%;
+`;

--- a/src/components/common/InputJoin.jsx
+++ b/src/components/common/InputJoin.jsx
@@ -11,14 +11,21 @@ const InputJoin = ({
   onClick,
   readOnly,
   width,
+  star,
 }) => {
   return (
     <Element>
-      <StyledInputTitle>
-        <span>{label.slice(0, -1)}</span>
-        <span>&nbsp;</span>
-        <span style={{ color: '#9259ff' }}>{label.slice(-1)}</span>
-      </StyledInputTitle>
+      {star ? (
+        <StyledInputTitle>
+          <span>{label.slice(0, -1)}</span>
+          <span>&nbsp;</span>
+          <span style={{ color: '#9259ff' }}>{label.slice(-1)}</span>
+        </StyledInputTitle>
+      ) : (
+        <StyledInputTitle>
+          <span>{label}</span>
+        </StyledInputTitle>
+      )}
       <StyledInput
         type={type}
         name={name}

--- a/src/components/login/LoginBox.jsx
+++ b/src/components/login/LoginBox.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Btn } from '../common/Button';
 import { COLORS } from '../../styles/theme';

--- a/src/pages/FindId.jsx
+++ b/src/pages/FindId.jsx
@@ -1,10 +1,14 @@
 import React from 'react';
+import FindForm from '../components/common/FindForm';
 
 const FindId = () => {
   return (
-    <>
-      <div>FindId</div>
-    </>
+    <FindForm
+      title='아이디 찾기 (휴대폰 인증)'
+      idLabel='사장님 성함'
+      serverEndpoint='/api/owner/findid'
+      postData='name'
+    />
   );
 };
 

--- a/src/pages/FindPw.jsx
+++ b/src/pages/FindPw.jsx
@@ -1,10 +1,14 @@
 import React from 'react';
+import FindForm from '../components/common/FindForm';
 
 const FindPw = () => {
   return (
-    <>
-      <div>FindPw</div>
-    </>
+    <FindForm
+      title='비밀번호 찾기 (휴대폰 인증)'
+      idLabel='아이디'
+      serverEndpoint='/api/owner/findpw'
+      postData='loginId'
+    />
   );
 };
 

--- a/src/pages/join/JoinOneStep.jsx
+++ b/src/pages/join/JoinOneStep.jsx
@@ -121,6 +121,7 @@ const JoinOneStep = () => {
               value={loginId}
               onChange={onChangeId}
               width='165px'
+              star={true}
             />
             <NewButton>중복 확인하기</NewButton>
           </Row>
@@ -133,6 +134,7 @@ const JoinOneStep = () => {
             type='password'
             value={password}
             onChange={onChangePassword}
+            star={true}
           />
           <Msg>{passwordMsg}</Msg>
         </div>
@@ -143,6 +145,7 @@ const JoinOneStep = () => {
             type='password'
             value={confirmPassword}
             onChange={onChangeConfirmPassword}
+            star={true}
           />
           <Msg>{confirmPasswordMsg}</Msg>
         </div>

--- a/src/pages/join/JoinTwoStep.jsx
+++ b/src/pages/join/JoinTwoStep.jsx
@@ -74,6 +74,7 @@ const JoinTwoStep = () => {
           value={name}
           width='520px'
           onChange={(e) => setName(e.target.value)}
+          star={true}
         />
         <Msg />
         <div>
@@ -83,6 +84,7 @@ const JoinTwoStep = () => {
             value={email}
             width='520px'
             onChange={onChangeEmail}
+            star={true}
           />
           <Msg>{emailMsg}</Msg>
         </div>
@@ -94,6 +96,7 @@ const JoinTwoStep = () => {
               value={phone}
               onChange={onChangePhone}
               width='337px'
+              star={true}
             />
             <NewButton>인증 받기</NewButton>
           </Row>
@@ -107,6 +110,7 @@ const JoinTwoStep = () => {
             value={certified}
             onChange={(e) => setCertified(e.target.value)}
             width='337px'
+            star={true}
           />
           <NewButton>인증번호 재발송</NewButton>
         </Row>


### PR DESCRIPTION
## 📍 작업 내용
- 아이디, 비밀번호 찾기 페이지
- (수정) '중복 확인하기' -> '인증 확인' 버튼 텍스트 수정
<br/>

## 📍 구현 결과 (선택)
![image](https://github.com/UMC-5th-Coumo/Coumo_Web/assets/102593738/a20e170e-13cf-4593-8734-10dda896ac0f)

![image](https://github.com/UMC-5th-Coumo/Coumo_Web/assets/102593738/a2997a2e-8ab3-4dc8-a4fe-222c9e67618c)


<br/>

## 📍 기타 사항
- common 폴더에 FindForm.jsx 컴포넌트로 FindId, FindPw 페이지 렌더링 했습니다!
- 인증부분 제외 서버 코드 작성했습니다.
<br/>
