### PR TITLE
[Style/#79]: 헤더, 랜딩 페이지 반응형 구현

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -13,9 +13,9 @@ const Header = () => {
   return (
     <Head>
       <HeaderBar>
-        <Link to='/'>
+        <LogoIcon to='/'>
           <Logo />
-        </Link>
+        </LogoIcon>
         {token ? (
           <Nav>
             <StyledLink to='/shop/basicInfo'>매장 관리</StyledLink>
@@ -70,7 +70,9 @@ const Head = styled.div`
 `;
 
 const HeaderBar = styled.div`
-  max-width: 1200px;
+  max-width: 1300px;
+  box-sizing: border-box;
+  padding: 0 30px;
   width: 100%;
   height: 52px;
   display: flex;
@@ -78,9 +80,15 @@ const HeaderBar = styled.div`
   justify-content: space-between;
 `;
 
+const LogoIcon = styled(Link)`
+  width: 100px;
+  height: 42px;
+  overflow-x: hidden;
+`;
+
 const Nav = styled.div`
   display: flex;
-  width: 550px;
+  width: 50%;
   justify-content: space-between;
   align-items: flex-start;
 `;

--- a/src/components/home/Banner.jsx
+++ b/src/components/home/Banner.jsx
@@ -17,7 +17,7 @@ const Banner = () => {
           가능합니다.
         </Description>
         <Icon>
-          <BannerIcon />
+          <BannerIcon width='100%' height='100%' viewBox='0 0 496 548' />
         </Icon>
       </Container>
     </Back>
@@ -50,7 +50,7 @@ const Title = styled.h1`
   text-align: center;
   text-shadow: 0px 6px 6.7px rgba(137, 74, 255, 0.3);
   font-family: 'GmarketSans';
-  font-size: 60px;
+  font-size: clamp(45px, 4vw, 60px);
   font-style: normal;
   font-weight: 700;
   line-height: 140%;
@@ -63,15 +63,22 @@ const Description = styled.span`
   max-width: 503px;
   color: ${COLORS.white};
   text-align: center;
-  font-size: 16px;
   font-style: normal;
   font-weight: 300;
   line-height: 180%; /* 28.8px */
   margin-top: 60px;
+  font-size: clamp(14px, 1.5vw, 16px);
 `;
 
 const Icon = styled.div`
   position: absolute;
-  bottom: 0;
-  right: 100px;
+  bottom: 10px;
+  right: 70px;
+
+  width: 30%;
+  /* height: 30%; */
+  min-height: 300px;
+  min-width: 300px;
+  max-width: 430px;
+  max-height: 430px;
 `;

--- a/src/components/home/Plan.jsx
+++ b/src/components/home/Plan.jsx
@@ -39,7 +39,7 @@ const Container = styled.div`
 const Title = styled.h2`
   margin: 0;
   color: ${COLORS.coumo_purple};
-  font-size: 25px;
+  font-size: clamp(20px, 2vw, 25px);
   font-style: normal;
   font-weight: 800;
   line-height: 25px;
@@ -57,7 +57,7 @@ const Term = styled.span`
 
 const Price = styled.span`
   color: ${COLORS.text_black};
-  font-size: 22px;
+  font-size: clamp(16px, 2vw, 22px);
   font-style: normal;
   font-weight: 700;
   letter-spacing: -0.5px;

--- a/src/components/home/PricePlan.jsx
+++ b/src/components/home/PricePlan.jsx
@@ -21,6 +21,7 @@ export default PricePlan;
 
 const Container = styled.div`
   width: 100%;
+  height: 400px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -42,5 +43,7 @@ const Title = styled.h2`
 
 const PlanBox = styled.div`
   display: flex;
+  justify-content: center;
+  width: 70%;
   gap: 16px;
 `;


### PR DESCRIPTION
## 📍 작업 내용
헤더, 랜딩 페이지 반응형 구현

<br/>

## 📍 구현 결과 (선택)
![화면 기록 2024-02-01 오전 12 25 35](https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/e7e7d615-6f00-44ed-8459-3f903c559bdd)
![화면 기록 2024-02-01 오전 12 32 53](https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/0c4e2684-f579-4468-8a36-a9099cb0d797)


<br/>

## 📍 기타 사항
폰트는 `font-size: clamp(20px, 2vw, 25px);` 이런 식으로 clamp 함수 사용했고 크기 조절은 전부 상대크기로 구현했습니다!

<br/>
