### PR TITLE
[Feat/#87]: 로그인 후 헤더 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,28 +14,57 @@ import JoinOneStep from './pages/join/JoinOneStep';
 import JoinTwoStep from './pages/join/JoinTwoStep';
 import Congratulate from './pages/join/Congratulate';
 import MyPage from './pages/MyPage';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+import AdminHeader from './components/common/AdminHeader';
+import AdminVerticalHeader from './components/common/AdminVerticalHeader';
 
 function App() {
+  const { token } = useSelector((state) => state.user);
   return (
     <>
       <GlobalStyle />
-      <Header />
-      <Routes>
-        <Route exact path='/' element={<Home />} />
-        <Route path='/shop/*' element={<Shop />} />
-        <Route path='/neighborhood/*' element={<Neighborhood />} />
-        <Route path='/coupon/*' element={<Coupon />} />
-        <Route path='/customer/*' element={<Customer />} />
-        <Route path='/mypage' element={<MyPage />} />
-        <Route path='/join/one' element={<JoinOneStep />} />
-        <Route path='/join/two' element={<JoinTwoStep />} />
-        <Route path='/join/finish' element={<Congratulate />} />
-        <Route path='/login' element={<Login />} />
-        <Route path='/findId' element={<FindId />} />
-        <Route path='/findPw' element={<FindPw />} />
-      </Routes>
+      {token ? (
+        <>
+          <AdminHeader />
+          <Container>
+            <AdminVerticalHeader />
+            <Wrapper>
+              <Routes>
+                <Route path='/shop/*' element={<Shop />} />
+                <Route path='/neighborhood/*' element={<Neighborhood />} />
+                <Route path='/coupon/*' element={<Coupon />} />
+                <Route path='/customer/*' element={<Customer />} />
+                <Route path='/mypage' element={<MyPage />} />
+              </Routes>
+            </Wrapper>
+          </Container>
+        </>
+      ) : (
+        <>
+          <Header />
+          <Routes>
+            <Route exact path='/' element={<Home />} />
+            <Route path='/join/one' element={<JoinOneStep />} />
+            <Route path='/join/two' element={<JoinTwoStep />} />
+            <Route path='/join/finish' element={<Congratulate />} />
+            <Route path='/login' element={<Login />} />
+            <Route path='/findId' element={<FindId />} />
+            <Route path='/findPw' element={<FindPw />} />
+          </Routes>
+        </>
+      )}
     </>
   );
 }
 
 export default App;
+
+const Container = styled.div`
+  display: flex;
+  width: 100vw;
+`;
+
+const Wrapper = styled.div`
+  width: calc(100vw - 250px);
+`;

--- a/src/components/common/AdminHeader.jsx
+++ b/src/components/common/AdminHeader.jsx
@@ -1,39 +1,33 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import Button from './Button';
 import { COLORS } from '../../styles/theme';
 import { Logo } from '../../assets';
-import Button from './Button';
 
-const Header = () => {
+function AdminHeader() {
   const navigate = useNavigate();
-
+  const { name } = useSelector((state) => state.user);
   return (
     <Head>
       <HeaderBar>
-        <LogoIcon to='/'>
+        <LogoContainer>
           <Logo />
-        </LogoIcon>
-
-        <Nav>
-          <StyledLink to='/shop/basicInfo'>매장 관리</StyledLink>
-          <StyledLink to='/neighborhood/writePost'>동네 소식</StyledLink>
-          <StyledLink to='/coupon/addCoupon'>쿠폰 관리</StyledLink>
-          <StyledLink to='/customer/manage'>고객 데이터 관리</StyledLink>
-        </Nav>
-
+        </LogoContainer>
         <Button
-          text='로그인/회원가입'
+          text={`${name} 사장님`}
+          color={COLORS.coumo_purple}
           onClickBtn={() => {
-            navigate('/login');
+            navigate('/mypage');
           }}
         ></Button>
       </HeaderBar>
     </Head>
   );
-};
+}
 
-export default Header;
+export default AdminHeader;
 
 const Head = styled.div`
   width: 100%;
@@ -43,7 +37,7 @@ const Head = styled.div`
   justify-content: center;
 
   box-sizing: border-box;
-  background-color: ${COLORS.white};
+  background-color: ${COLORS.coumo_lightpurple};
   font-family: 'Pretendard';
   font-size: 16px;
   position: absolute;
@@ -62,21 +56,8 @@ const HeaderBar = styled.div`
   justify-content: space-between;
 `;
 
-const LogoIcon = styled(Link)`
+const LogoContainer = styled.div`
   width: 100px;
   height: 42px;
   overflow-x: hidden;
-`;
-
-const Nav = styled.div`
-  display: flex;
-  width: 50%;
-  justify-content: space-between;
-  align-items: flex-start;
-`;
-
-const StyledLink = styled(Link)`
-  color: ${COLORS.text_darkgray};
-  font-weight: 600;
-  text-decoration-line: none;
 `;

--- a/src/components/common/AdminVerticalHeader.jsx
+++ b/src/components/common/AdminVerticalHeader.jsx
@@ -1,0 +1,162 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { COLORS } from '../../styles/theme';
+import { Link, useLocation } from 'react-router-dom';
+
+function AdminVerticalHeader() {
+  const [selected, setSelected] = useState('');
+  const [current, setCurrent] = useState('/mypage');
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    setCurrent(pathname);
+  }, [pathname]);
+
+  const handleSelectMenu = (menu) => {
+    if (selected === menu) {
+      setSelected('');
+    } else {
+      setSelected(menu);
+    }
+  };
+
+  return (
+    <Container>
+      <Menu open={selected === 'shop'} size={100}>
+        <MenuTitle onClick={() => handleSelectMenu('shop')}>
+          매장 관리
+        </MenuTitle>
+        <SubMenu>
+          <SubMenuLink
+            to='/shop/basicInfo'
+            current={current === '/shop/basicInfo'}
+          >
+            기본 정보
+          </SubMenuLink>
+          <SubMenuLink
+            to='/shop/storeInfo'
+            current={current === '/shop/storeInfo'}
+          >
+            매장 설명
+          </SubMenuLink>
+        </SubMenu>
+      </Menu>
+      <Menu open={selected === 'neighborhood'} size={100}>
+        <MenuTitle onClick={() => handleSelectMenu('neighborhood')}>
+          동네 소식
+        </MenuTitle>
+        <SubMenu>
+          <SubMenuLink
+            to='/neighborhood/writePost'
+            current={current === '/neighborhood/writePost'}
+          >
+            글쓰기
+          </SubMenuLink>
+          <SubMenuLink
+            to='/neighborhood/myPosts'
+            current={current.includes('myPosts')}
+          >
+            내가 쓴 글
+          </SubMenuLink>
+        </SubMenu>
+      </Menu>
+      <Menu open={selected === 'coupon'} size={100}>
+        <MenuTitle onClick={() => handleSelectMenu('coupon')}>
+          쿠폰 관리
+        </MenuTitle>
+        <SubMenu>
+          <SubMenuLink
+            to='/coupon/addCoupon'
+            current={current === '/coupon/addCoupon'}
+          >
+            쿠폰 등록하기
+          </SubMenuLink>
+          <SubMenuLink
+            to='/coupon/uiService'
+            current={
+              current === '/coupon/uiService' ||
+              current === '/coupon/uiServiceForm'
+            }
+          >
+            쿠폰 UI 서비스 구매하기
+          </SubMenuLink>
+        </SubMenu>
+      </Menu>
+      <Menu open={selected === 'store'} size={130}>
+        <MenuTitle onClick={() => handleSelectMenu('store')}>
+          고객 데이터 관리
+        </MenuTitle>
+        <SubMenu>
+          <SubMenuLink
+            to='/customer/manage'
+            current={current === '/customer/manage'}
+          >
+            고객 관리
+          </SubMenuLink>
+          <SubMenuLink
+            to='/customer/visit'
+            current={current === '/customer/visit'}
+          >
+            방문 분석
+          </SubMenuLink>
+          <SubMenuLink
+            to='/customer/report'
+            current={current === '/customer/report'}
+          >
+            월간 레포트 분석
+          </SubMenuLink>
+        </SubMenu>
+      </Menu>
+    </Container>
+  );
+}
+
+export default AdminVerticalHeader;
+
+const Container = styled.div`
+  width: 250px;
+  border-right: 1px solid lightgray;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-sizing: border-box;
+  padding-top: 50px;
+  padding-left: 50px;
+  overflow: hidden;
+  gap: 30px;
+`;
+
+const Menu = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  color: ${COLORS.text_darkgray};
+  padding-left: 40px;
+  border-bottom: 1px solid lightgray;
+  overflow: hidden;
+  height: ${(props) => (props.open ? props.size : 35)}px;
+  transition: height 0.3s ease-in-out;
+  cursor: pointer;
+`;
+
+const MenuTitle = styled.h5`
+  margin: 0;
+  font-size: 16px;
+`;
+
+const SubMenu = styled.div`
+  flex-direction: column;
+  gap: 12px;
+  display: flex;
+  margin: 16px 0px;
+`;
+
+const SubMenuLink = styled(Link)`
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 14px;
+  text-decoration: none;
+  color: ${(props) =>
+    props.current ? COLORS.coumo_purple : COLORS.text_darkgray};
+  font-weight: 600;
+`;

--- a/src/pages/Coupon.jsx
+++ b/src/pages/Coupon.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import styled from 'styled-components';
-import TabBar from '../components/common/TabBar';
-import { couponTabs } from '../assets/data/tabData';
 import AddCoupon from './coupon/AddCoupon';
 import UIServiceAd from './coupon/UIServiceAd';
 import UIServiceForm from './coupon/UIServiceForm';
@@ -10,8 +8,6 @@ import UIServiceForm from './coupon/UIServiceForm';
 const Coupon = () => {
   return (
     <Container>
-      <TabBar tabs={couponTabs} />
-
       <Routes>
         <Route path='/addCoupon' element={<AddCoupon />} />
         <Route path='/uiService' element={<UIServiceAd />} />

--- a/src/pages/Customer.jsx
+++ b/src/pages/Customer.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { customerTabMenu } from '../assets/data/tabData';
-import TabMenuBar from '../components/admin/customer/common/tabMenu/TabMenuBar';
 import { Route, Routes } from 'react-router-dom';
 import CustomerManage from './customer/CustomerManage';
 import VisitAnalysis from './customer/VisitAnalysis';
@@ -10,7 +8,6 @@ import MonthlyReport from './customer/MonthlyReport';
 const Customer = () => {
   return (
     <Container>
-      <TabMenuBar tabs={customerTabMenu} />
       <Routes>
         <Route exact path='manage' element={<CustomerManage />} />
         <Route exact path='visit' element={<VisitAnalysis />} />
@@ -23,7 +20,6 @@ const Customer = () => {
 export default Customer;
 
 const Container = styled.div`
-  width: 100vw;
   box-sizing: border-box;
   padding: 70px 120px 0px 120px;
   display: flex;

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -9,7 +9,6 @@ function MyPage() {
   const { name, id, email, phone } = useSelector((state) => state.user);
   return (
     <Container>
-      <Tab>마이페이지</Tab>
       <TitleBox>
         <Title title={`안녕하세요, ${name}님!`} size={22} />
         <Line />
@@ -84,27 +83,6 @@ const Content = styled.div`
     font-weight: 600;
     line-height: normal;
   }
-`;
-
-const Tab = styled.div`
-  display: flex;
-  width: 150px;
-  height: 25px;
-  padding: 8px 6px;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
-  flex-shrink: 0;
-  border-radius: 12px 12px 0px 0px;
-  background: ${(props) =>
-    props.selected ? COLORS.coumo_purple : COLORS.btn_lightgray};
-  color: ${(props) => (props.selected ? COLORS.white_fff : COLORS.tab_gray)};
-  font-size: 13px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 132%; /* 21.12px */
-  letter-spacing: 0.48px;
-  margin-top: 70px;
 `;
 
 const TitleBox = styled.div`

--- a/src/pages/Neighborhood.jsx
+++ b/src/pages/Neighborhood.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import styled from 'styled-components';
-import { writingTabs } from '../assets/data/tabData';
-import TabBar from '../components/common/TabBar';
 import WritePost from './neighborhood/WritePost';
 import MyPosts from './neighborhood/MyPosts';
 import MyPostView from './neighborhood/MyPostView';
@@ -11,12 +9,11 @@ import MyEdit from './neighborhood/MyEdit';
 const Neighborhood = () => {
   return (
     <Container>
-      <TabBar tabs={writingTabs} />
       <Routes>
         <Route path='/writePost' element={<WritePost />} />
         <Route path='/myPosts' element={<MyPosts />} />
-        <Route path='/myPostView/:postId' element={<MyPostView />} />
-        <Route path='/myEdit/:postId' element={<MyEdit />} />
+        <Route path='/myPosts/myPostView/:postId' element={<MyPostView />} />
+        <Route path='/myPosts/myEdit/:postId' element={<MyEdit />} />
       </Routes>
     </Container>
   );

--- a/src/pages/Shop.jsx
+++ b/src/pages/Shop.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
-import TabBar from '../components/common/TabBar';
-import { basicInfoTabs } from '../assets/data/tabData';
 import styled from 'styled-components';
 import BasicInfo from './shop/BasicInfo';
 import StoreInfo from './shop/StoreInfo';
@@ -9,7 +7,6 @@ import StoreInfo from './shop/StoreInfo';
 const Shop = () => {
   return (
     <Container>
-      <TabBar tabs={basicInfoTabs} />
       <Routes>
         <Route path='/basicInfo' element={<BasicInfo />} />
         <Route path='/storeInfo' element={<StoreInfo />} />

--- a/src/pages/neighborhood/MyPostView.jsx
+++ b/src/pages/neighborhood/MyPostView.jsx
@@ -17,7 +17,7 @@ const MyPostView = () => {
   const postDummyData = location.state.postDummyData;
 
   const onClickMod = () => {
-    navigate(`/neighborhood/myEdit/${postId}`, {
+    navigate(`/neighborhood/myPosts/myEdit/${postId}`, {
       state: { post: selectedPost, postDummyData },
     });
   };

--- a/src/pages/neighborhood/MyPosts.jsx
+++ b/src/pages/neighborhood/MyPosts.jsx
@@ -55,14 +55,14 @@ const MyPosts = () => {
 
   const handlePostClick = (postIndex) => {
     const postId = postDummyData[postIndex].id;
-    navigate(`/neighborhood/myPostView/${postId}`, {
+    navigate(`/neighborhood/myPosts/myPostView/${postId}`, {
       state: { post: postDummyData[postIndex], postDummyData },
     });
   };
 
   const handleModifyClick = (postIndex) => {
     const postId = postDummyData[postIndex].id;
-    navigate(`/neighborhood/myEdit/${postId}`, {
+    navigate(`/neighborhood/myPosts/myEdit/${postId}`, {
       state: { post: postDummyData[postIndex], postDummyData },
     });
   };


### PR DESCRIPTION
## 📍 작업 내용
로그인 후 헤더 구현

<br/>

## 📍 구현 결과 (선택)
![화면 기록 2024-02-01 오후 10 03 47](https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/e0c0f405-30e6-45f3-9e32-571274258df9)


<br/>

## 📍 기타 사항
- 로그인 전후 헤더를 아예 각각의 컴포넌트로 분리했고 로그인 후 세로 헤더도 따로 만들었습니다!
- 로그인 전에는 홈화면/로그인/회원가입 등 화면만 라우팅 되도록하고 로그인 후에는 관리 페이지들만 라우팅 했어요 (나중에 url 직접 입력해서 접근하는 걸 막던지 404 페이지를 띄워야할 듯)
<img width="690" alt="스크린샷 2024-02-01 오후 10 10 32" src="https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/4755ef28-be84-427a-9aa0-2d890ae76f38">


<br/>
