### PR TITLE
[Style/#105]: ThemeProvider 적용

### DIFF
--- a/src/components/admin/coupon/Category.jsx
+++ b/src/components/admin/coupon/Category.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import RadioBtn from '../../common/RadioBtn';
-import { COLORS } from '../../../styles/theme';
 
 const Category = ({ data, category, setCategory, columns, all }) => {
   const onChange = (id) => {
@@ -47,8 +46,8 @@ const Container = styled.div`
 `;
 
 const Title = styled.h2`
-  color: ${COLORS.coumo_purple};
-  font-size: 19px;
+  color: ${({ theme }) => theme.colors.coumo_purple};
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 700;
   line-height: 132%; /* 31.68px */

--- a/src/components/admin/coupon/ColorPicker.jsx
+++ b/src/components/admin/coupon/ColorPicker.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../styles/theme';
 import { ChromePicker } from 'react-color';
 
 const ColorPicker = ({ open, setOpen, color, setColor }) => {
@@ -22,7 +21,7 @@ const ColorPicker = ({ open, setOpen, color, setColor }) => {
 export default ColorPicker;
 
 const ColorBox = styled.button`
-  background: ${COLORS.white_fff};
+  background: ${({ theme }) => theme.colors.white_fff};
   border-radius: 4px;
   display: flex;
   height: 38.5px;
@@ -32,10 +31,10 @@ const ColorBox = styled.button`
   border: 1px solid #d8d8d8;
   width: 110px;
 
-  color: ${COLORS.text_darkgray};
+  color: ${({ theme }) => theme.colors.text_darkgray};
   text-overflow: ellipsis;
   font-family: 'Pretendard';
-  font-size: 13px;
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   font-weight: 400;
   line-height: 170%; /* 27.2px */

--- a/src/components/admin/coupon/CouponStep.jsx
+++ b/src/components/admin/coupon/CouponStep.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../styles/theme';
 
 const CouponStep = ({ id, step, description }) => {
   return (
@@ -35,9 +34,9 @@ const Number = styled.div`
   align-items: center;
   flex-shrink: 0;
   border-radius: 20px;
-  background: ${COLORS.coumo_purple};
-  color: ${COLORS.white_fff};
-  font-size: 14px;
+  background: ${({ theme }) => theme.colors.coumo_purple};
+  color: ${({ theme }) => theme.colors.white_fff};
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-style: normal;
   font-weight: 700;
   line-height: 23.8px; /* 170% */
@@ -51,15 +50,15 @@ const Divider = styled.div`
   left: 100%;
   width: 260px;
   height: 1px;
-  background-color: ${COLORS.coumo_purple};
+  background-color: ${({ theme }) => theme.colors.coumo_purple};
   transform: translateY(-50%);
   z-index: 0;
 `;
 
 const Title = styled.div`
-  color: ${COLORS.coumo_purple};
+  color: ${({ theme }) => theme.colors.coumo_purple};
   text-align: center;
-  font-size: 20px;
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 700;
   line-height: 28px; /* 140% */
@@ -67,9 +66,9 @@ const Title = styled.div`
 `;
 
 const Text = styled.div`
-  color: ${COLORS.text_darkgray};
+  color: ${({ theme }) => theme.colors.text_darkgray};
   text-align: center;
-  font-size: 16px;
+  font-size: ${({ theme }) => theme.fontSize.md};
   font-style: normal;
   font-weight: 600;
   line-height: 28px; /* 175% */

--- a/src/components/admin/coupon/RadioButton.jsx
+++ b/src/components/admin/coupon/RadioButton.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../styles/theme';
 
 const RadioButton = ({ id, label, selected, onChange }) => {
   return (
@@ -29,8 +28,8 @@ const RadioLabel = styled.label`
   gap: 8px;
   flex-shrink: 0;
   border-radius: 4px;
-  background: ${(props) =>
-    props.selected ? COLORS.coumo_gray : COLORS.white_fff};
+  background: ${({ theme, selected }) =>
+    selected ? theme.colors.coumo_gray : theme.colors.white_fff};
   border: 1px solid #d8d8d8;
   cursor: pointer;
 `;
@@ -43,10 +42,10 @@ const RadioInput = styled.input`
   width: 1.3em;
   height: 1.3em;
   transition: border 0.5s ease-in-out;
-  background-color: ${COLORS.white};
+  background-color: ${({ theme }) => theme.colors.white};
 
   &:checked {
-    border: 0.67em solid ${COLORS.coumo_purple};
+    border: 0.67em solid ${({ theme }) => theme.colors.coumo_purple};
   }
 
   &:hover {
@@ -60,7 +59,7 @@ const RadioSpan = styled.span`
   color: #545252;
   text-overflow: ellipsis;
   font-family: 'Pretendard';
-  font-size: 12.8px;
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   line-height: 170%; /* 27.2px */
   font-weight: ${(props) => (props.selected ? '600' : '400')};

--- a/src/components/admin/coupon/ReasonCard.jsx
+++ b/src/components/admin/coupon/ReasonCard.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../styles/theme';
 
 const ReasonCard = ({ id, img, title, description }) => {
   return (
@@ -23,7 +22,7 @@ const Card = styled.div`
   padding: 24px;
   gap: 8px;
   border-radius: 24px;
-  background: ${COLORS.white_fefe};
+  background: ${({ theme }) => theme.colors.white_fefe};
   box-shadow: 12px 15px 14.8px 0px rgba(87, 76, 108, 0.1);
   backdrop-filter: blur(4px);
 `;
@@ -34,9 +33,9 @@ const CardImage = styled.div`
 `;
 
 const Reason = styled.div`
-  color: ${COLORS.coumo_purple};
+  color: ${({ theme }) => theme.colors.coumo_purple};
   text-align: center;
-  font-size: 20px;
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 800;
   line-height: 100%; /* 20px */
@@ -47,7 +46,7 @@ const Reason = styled.div`
 const Text = styled.div`
   color: #635f6a;
   text-align: center;
-  font-size: 14px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-style: normal;
   font-weight: 400;
   line-height: 22px; /* 157.143% */

--- a/src/components/admin/coupon/Stamp.jsx
+++ b/src/components/admin/coupon/Stamp.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../styles/theme';
 
 const Stamp = ({ id, stamp, selected, onChange }) => {
   return (
@@ -30,8 +29,8 @@ const RadioLabel = styled.label`
   gap: 8px;
   flex-shrink: 0;
   border-radius: 4px;
-  background: ${(props) =>
-    props.selected ? COLORS.coumo_purple : COLORS.white_fff};
+  background: ${({ theme, selected }) =>
+    selected ? theme.colors.coumo_purple : theme.colors.white_fff};
 
   border: 1px solid #d8d8d8;
   cursor: pointer;
@@ -48,7 +47,7 @@ const RadioInput = styled.input`
   display: none;
 
   &:checked {
-    border: 0.67em solid ${COLORS.coumo_purple};
+    border: 0.67em solid ${({ theme }) => theme.colors.coumo_purple};
   }
 
   &:hover {
@@ -61,11 +60,12 @@ const RadioSpan = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   font-family: 'Pretendard';
-  font-size: 12.8px;
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   font-weight: 400;
   line-height: 170%; /* 27.2px */
-  color: ${(props) => (props.selected ? COLORS.white_fff : '#545252')};
+  color: ${({ theme, selected }) =>
+    selected ? theme.colors.white_fff : '#545252'};
 `;
 
 const StampIcon = styled.img`

--- a/src/components/admin/customer/customerManage/CustomerDetail.jsx
+++ b/src/components/admin/customer/customerManage/CustomerDetail.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../../styles/theme';
 import userImage from '../../../../assets/image/userImage.png';
 
 function CustomerDetail({ data }) {
@@ -42,7 +41,7 @@ const Container = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: 32px;
-  background-color: ${COLORS.card_lightpurple};
+  background-color: ${({ theme }) => theme.colors.card_lightpurple};
   border-radius: 12px;
 
   @media screen and (max-width: 1280px) {
@@ -91,25 +90,25 @@ const ProfileContent = styled.div`
   & h5 {
     margin: 0;
     color: #565160;
-    font-size: 19px;
+    font-size: ${({ theme }) => theme.fontSize.md};
     font-style: normal;
     font-weight: 700;
     line-height: 132%; /* 31.68px */
     letter-spacing: 0.96px;
 
     @media screen and (max-width: 1280px) {
-      font-size: 16px;
+      font-size: ${({ theme }) => theme.fontSize.base};
     }
   }
 
   & span {
     color: #565160;
-    font-size: 19px;
+    font-size: ${({ theme }) => theme.fontSize.base};
     font-style: normal;
     line-height: 132%; /* 31.68px */
 
     @media screen and (max-width: 1280px) {
-      font-size: 14px;
+      font-size: ${({ theme }) => theme.fontSize.sm};
     }
   }
 `;
@@ -127,13 +126,13 @@ const InfoContent = styled.div`
 
   & span {
     color: #565160;
-    font-size: 16px;
+    font-size: ${({ theme }) => theme.fontSize.base};
     font-style: normal;
     line-height: 132%; /* 26.4px */
     letter-spacing: 0.2px;
 
     @media screen and (max-width: 1280px) {
-      font-size: 14px;
+      font-size: ${({ theme }) => theme.fontSize.sm};
     }
   }
 `;
@@ -144,10 +143,10 @@ const RecentVisit = styled.span`
   padding: 0px 16px;
   align-items: center;
   border-radius: 46px;
-  background: ${COLORS.coumo_purple};
-  color: ${COLORS.white_fff};
+  background: ${({ theme }) => theme.colors.coumo_purple};
+  color: ${({ theme }) => theme.colors.white_fff};
   text-align: center;
-  font-size: 10px;
+  font-size: ${({ theme }) => theme.fontSize.xs};
   font-style: normal;
   font-weight: 500;
   line-height: 100%; /* 16px */

--- a/src/components/admin/customer/customerManage/CustomerList.jsx
+++ b/src/components/admin/customer/customerManage/CustomerList.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../../styles/theme';
 
 function CustomerList({ customerData, selected, setSelected }) {
   return (
@@ -69,10 +68,10 @@ const Column = styled.span`
   border-radius: 34px;
   background: #e2e0e8;
 
-  color: ${COLORS.coumo_purple};
+  color: ${({ theme }) => theme.colors.coumo_purple};
   text-align: center;
   font-family: 'Pretendard';
-  font-size: 13px;
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   font-weight: 600;
   line-height: 132%; /* 21.12px */
@@ -93,23 +92,23 @@ const Customer = styled.div`
   gap: 12px;
   border-bottom: 1px solid #e3e1e8;
   cursor: pointer;
-  background-color: ${(props) =>
-    props.selected ? COLORS.card_lightpurple : COLORS.white};
+  background-color: ${({ theme, selected }) =>
+    selected ? theme.colors.card_lightpurple : theme.colors.white};
 
   &:hover {
-    background-color: ${COLORS.card_lightpurple};
+    background-color: ${({ theme }) => theme.colors.card_lightpurple};
   }
 
   & span {
     width: 130px;
     text-align: center;
-    font-size: 13px;
+    font-size: ${({ theme }) => theme.fontSize.sm};
     padding: 15px 0px;
     margin: 0px 10px;
     box-sizing: border-box;
 
     @media screen and (max-width: 1280px) {
-      font-size: 12px;
+      font-size: ${({ theme }) => theme.fontSize.xs};
     }
   }
 `;

--- a/src/components/admin/customer/monthlyReport/MonthPicker.jsx
+++ b/src/components/admin/customer/monthlyReport/MonthPicker.jsx
@@ -3,9 +3,11 @@ import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { ko } from 'date-fns/locale';
 import styled from 'styled-components';
-import { COLORS } from '../../../../styles/theme';
 import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
 import { getMonth, getYear } from 'date-fns';
+import { theme } from '../../../../styles/theme';
+
+const { colors } = theme;
 
 const MonthPicker = () => {
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -50,7 +52,7 @@ const MonthPicker = () => {
           >
             <IoIosArrowBack
               style={{ height: '20px', width: '20px' }}
-              fill={COLORS.text_darkgray}
+              fill={colors.text_darkgray}
             />
           </Button>
           <TextBox>
@@ -63,7 +65,7 @@ const MonthPicker = () => {
           >
             <IoIosArrowForward
               style={{ height: '20px', width: '20px' }}
-              fill={COLORS.text_darkgray}
+              fill={colors.text_darkgray}
             />
           </Button>
         </Header>
@@ -84,10 +86,10 @@ const CustomInput = styled.input`
   box-sizing: border-box;
   border: none;
   border-radius: 16px 16px 0px 0px;
-  background: ${COLORS.btn_lightgray};
+  background: ${({ theme }) => theme.colors.btn_lightgray};
 
   text-align: center;
-  color: ${COLORS.coumo_purple};
+  color: ${({ theme }) => theme.colors.coumo_purple};
   font-style: normal;
   font-weight: 600;
   line-height: 132%;
@@ -105,7 +107,7 @@ const Header = styled.div`
   height: 16px;
   display: flex;
   justify-content: space-between;
-  background-color: ${COLORS.white_fff};
+  background-color: ${({ theme }) => theme.colors.white_fff};
   font-family: 'Pretendard';
 `;
 

--- a/src/components/admin/customer/visitAnalysis/Calendar.jsx
+++ b/src/components/admin/customer/visitAnalysis/Calendar.jsx
@@ -2,10 +2,10 @@ import React, { useState } from 'react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import styled from 'styled-components';
-import { COLORS } from '../../../../styles/theme';
 import { ko } from 'date-fns/locale';
 import { getMonth, getYear } from 'date-fns';
 import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
+import { theme } from '../../../../styles/theme';
 
 const months = [
   '1월',
@@ -21,6 +21,8 @@ const months = [
   '11월',
   '12월',
 ];
+
+const { colors } = theme;
 
 const Calendar = () => {
   const [dateRange, setDateRange] = useState([null, null]);
@@ -69,7 +71,7 @@ const Calendar = () => {
             >
               <IoIosArrowBack
                 style={{ height: '20px', width: '20px' }}
-                fill={COLORS.text_darkgray}
+                fill={colors.text_darkgray}
               />
             </Button>
             <TextBox>
@@ -83,7 +85,7 @@ const Calendar = () => {
             >
               <IoIosArrowForward
                 style={{ height: '20px', width: '20px' }}
-                fill={COLORS.text_darkgray}
+                fill={colors.text_darkgray}
               />
             </Button>
           </Header>
@@ -97,7 +99,7 @@ export default Calendar;
 
 const Container = styled.div`
   width: 230px;
-  font-size: 14px;
+  font-size: ${({ theme }) => theme.fontSize.base};
 `;
 
 const CustomInput = styled.input`
@@ -110,10 +112,10 @@ const CustomInput = styled.input`
   box-sizing: border-box;
   border: none;
   border-radius: 16px 16px 0px 0px;
-  background: ${COLORS.btn_lightgray};
+  background: ${({ theme }) => theme.colors.btn_lightgray};
 
   text-align: center;
-  color: ${COLORS.coumo_purple};
+  color: ${({ theme }) => theme.colors.coumo_purple};
   font-style: normal;
   font-weight: 600;
   line-height: 132%;
@@ -136,7 +138,7 @@ const Header = styled.div`
   height: 16px;
   display: flex;
   justify-content: space-between;
-  background-color: ${COLORS.white_fff};
+  background-color: ${({ theme }) => theme.colors.white_fff};
   font-family: 'Pretendard';
 `;
 

--- a/src/components/admin/customer/visitAnalysis/VisitCount.jsx
+++ b/src/components/admin/customer/visitAnalysis/VisitCount.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../../styles/theme';
 import { ArrowDown, ArrowUp } from '../../../../assets';
 
 function VisitCount({ type, text }) {
@@ -34,7 +33,7 @@ const Content = styled.div`
   gap: 8px;
 
   & span {
-    font-size: 12.8px;
+    font-size: ${({ theme }) => theme.fontSize.sm};
     color: #7d7788;
     font-style: normal;
     font-weight: 500;
@@ -42,21 +41,21 @@ const Content = styled.div`
     letter-spacing: 0.16px;
 
     & strong {
-      color: ${COLORS.coumo_purple};
+      color: ${({ theme }) => theme.colors.coumo_purple};
     }
 
     @media screen and (max-width: 1024px) {
-      font-size: 11px;
+      font-size: ${({ theme }) => theme.fontSize.xs};
     }
   }
 
   & h5 {
     margin: 0;
-    font-size: 19px;
-    color: ${COLORS.coumo_purple};
+    font-size: ${({ theme }) => theme.fontSize.lg};
+    color: ${({ theme }) => theme.colors.coumo_purple};
 
     @media screen and (max-width: 1024px) {
-      font-size: 16px;
+      font-size: ${({ theme }) => theme.fontSize.md};
     }
   }
 `;

--- a/src/components/admin/customer/visitAnalysis/groupTab/GroupTab.jsx
+++ b/src/components/admin/customer/visitAnalysis/groupTab/GroupTab.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../../../styles/theme';
 
 const GroupTab = ({ text, onClickTab, isSelected }) => {
   return (
@@ -21,17 +20,18 @@ const TabDiv = styled.div`
   align-items: center;
   cursor: pointer;
   border-radius: 16px 16px 0px 0px;
-  background: ${(props) =>
-    props.selected ? COLORS.coumo_purple : COLORS.btn_lightgray};
-  color: ${(props) => (props.selected ? COLORS.white_fff : COLORS.tab_gray)};
-  font-size: 13px;
+  background: ${({ theme, selected }) =>
+    selected ? theme.colors.coumo_purple : theme.colors.btn_lightgray};
+  color: ${({ theme, selected }) =>
+    selected ? theme.colors.white_fff : theme.colors.tab_gray};
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-weight: ${(props) => (props.selected ? '700' : '500')};
   line-height: 132%; /* 21.12px */
   letter-spacing: 0.48px;
 
   @media screen and (max-width: 1024px) {
     height: 30px;
-    font-size: 11px;
+    font-size: ${({ theme }) => theme.fontSize.xs};
     padding: 8px 6px;
   }
 `;

--- a/src/components/admin/customer/visitAnalysis/index/Index.jsx
+++ b/src/components/admin/customer/visitAnalysis/index/Index.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../../../styles/theme';
 
 const Index = ({ text, onClickTab, isSelected }) => {
   return (
@@ -24,10 +23,11 @@ const TabDiv = styled.div`
 
   cursor: pointer;
   border-radius: 0px 24px 24px 0px;
-  background: ${(props) =>
-    props.selected ? COLORS.coumo_purple : COLORS.btn_lightgray};
-  color: ${(props) => (props.selected ? COLORS.white_fff : COLORS.tab_gray)};
-  font-size: 13px;
+  background: ${({ theme, selected }) =>
+    selected ? theme.colors.coumo_purple : theme.colors.btn_lightgray};
+  color: ${({ theme, selected }) =>
+    selected ? theme.colors.white_fff : theme.colors.tab_gray};
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-weight: ${(props) => (props.selected ? '700' : '500')};
   line-height: 132%;
   letter-spacing: 0.48px;

--- a/src/components/admin/customer/visitAnalysis/index/IndexBar.jsx
+++ b/src/components/admin/customer/visitAnalysis/index/IndexBar.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import Index from './Index';
-import { COLORS } from '../../../../../styles/theme';
 
 const IndexBar = ({ tabs, selected, setSelected }) => {
   const handleTabClick = (key) => {
@@ -36,10 +35,10 @@ const Bar = styled.div`
 `;
 
 const Span = styled.span`
-  color: ${COLORS.tab_gray};
+  color: ${({ theme }) => theme.colors.tab_gray};
   padding-left: 48px;
   box-sizing: border-box;
-  font-size: 13px;
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   font-weight: 600;
   line-height: 100%;

--- a/src/components/admin/customer/visitAnalysis/tabMenu/TabMenu.jsx
+++ b/src/components/admin/customer/visitAnalysis/tabMenu/TabMenu.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../../../styles/theme';
 
 const TabMenu = ({ text, onClickTab, isSelected }) => {
   return (
@@ -22,8 +21,9 @@ const TabDiv = styled.div`
   justify-content: center;
   align-items: center;
 
-  color: ${(props) => (props.selected ? COLORS.coumo_purple : COLORS.tab_gray)};
-  font-size: 13px;
+  color: ${({ theme, selected }) =>
+    selected ? theme.colors.coumo_purple : theme.colors.tab_gray};
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   font-weight: 700;
   line-height: 22px; /* 137.5% */
@@ -35,8 +35,8 @@ const TabDiv = styled.div`
 const Selector = styled.div`
   width: 100%;
   height: 4px;
-  background-color: ${(props) =>
-    props.selected ? COLORS.coumo_purple : 'none'};
+  background-color: ${({ theme, selected }) =>
+    selected ? theme.colors.coumo_purple : 'none'};
   border-radius: 30px;
 
   position: absolute;

--- a/src/components/admin/neighborhood/ConfirmModal.jsx
+++ b/src/components/admin/neighborhood/ConfirmModal.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../styles/theme';
 import { fadeIn } from '../../../styles/GlobalStyle';
 
 const ConfirmModal = ({ title, onCancel, onConfirm }) => {
@@ -38,15 +37,15 @@ const Modal = styled.div`
   align-items: center;
   gap: 8px;
   border-radius: 12px;
-  background: ${COLORS.coumo_lightpurple};
+  background: ${({ theme }) => theme.colors.coumo_lightpurple};
   animation: ${fadeIn} 1s;
 `;
 
 const Title = styled.span`
   overflow: hidden;
-  color: ${COLORS.coumo_purple};
+  color: ${({ theme }) => theme.colors.coumo_purple};
   text-align: center;
-  font-size: 19px;
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 600;
   line-height: 132%;
@@ -64,20 +63,20 @@ const BaseButton = styled.button`
   flex: 1;
   padding: 10px;
   border-radius: 8px;
-  font-size: 14px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-weight: 600;
   transition: box-shadow 0.4s;
 `;
 
 const CancelButton = styled(BaseButton)`
-  background-color: ${COLORS.coumo_lightpurple};
-  color: ${COLORS.coumo_purple};
+  background-color: ${({ theme }) => theme.colors.coumo_lightpurple};
+  color: ${({ theme }) => theme.colors.coumo_purple};
   border: none;
 `;
 
 const DeleteButton = styled(BaseButton)`
-  background-color: ${COLORS.coumo_purple};
-  color: ${COLORS.white_fff};
+  background-color: ${({ theme }) => theme.colors.coumo_purple};
+  color: ${({ theme }) => theme.colors.white_fff};
   border: none;
 
   &:hover {

--- a/src/components/admin/neighborhood/Post.jsx
+++ b/src/components/admin/neighborhood/Post.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../styles/theme';
 import TagButton from './TagButton';
 
 const Post = ({ data, onClick, onModify, onDelete }) => {
@@ -33,7 +32,7 @@ const Container = styled.div`
   box-sizing: border-box;
   padding: 20px 40px 20px;
   justify-content: space-between;
-  background: ${COLORS.white_fff};
+  background: ${({ theme }) => theme.colors.white_fff};
   border-top: 2px solid #e0e0e0;
   border-bottom: 2px solid #e0e0e0;
 
@@ -42,7 +41,7 @@ const Container = styled.div`
   }
 
   &:hover {
-    background: ${COLORS.post_lightgray};
+    background: ${({ theme }) => theme.colors.post_lightgray};
   }
 `;
 
@@ -70,7 +69,7 @@ const Title = styled.h2`
   width: 260px;
   margin: 0;
   color: #5a5369;
-  font-size: 18px;
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 600;
 
@@ -83,7 +82,7 @@ const Title = styled.h2`
 `;
 
 const Date = styled.div`
-  font-size: 16px;
+  font-size: ${({ theme }) => theme.fontSize.md};
   color: #3b3648;
 `;
 
@@ -102,9 +101,9 @@ const PostButton = styled.button`
   gap: 8px;
   border-radius: 6px;
   border: 1.5px solid rgba(144, 133, 165, 0.4);
-  background: ${COLORS.white_fff};
-  color: ${COLORS.text_darkgray};
-  font-size: 13px;
+  background: ${({ theme }) => theme.colors.white_fff};
+  color: ${({ theme }) => theme.colors.text_darkgray};
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   font-weight: 600;
   line-height: 132%; /* 21.12px */

--- a/src/components/admin/neighborhood/TagButton.jsx
+++ b/src/components/admin/neighborhood/TagButton.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../styles/theme';
 
 const TagButton = ({ label }) => {
   return <Container>{label}</Container>;
@@ -20,9 +19,9 @@ const Container = styled.span`
   background: #6746a6;
 
   overflow: hidden;
-  color: ${COLORS.white};
+  color: ${({ theme }) => theme.colors.white};
   text-overflow: ellipsis;
-  font-size: 13px;
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   font-weight: 500;
   line-height: 170%; /* 28.56px */

--- a/src/components/admin/shop/ImageBlock.jsx
+++ b/src/components/admin/shop/ImageBlock.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../styles/theme';
 import { Plus } from '../../../assets';
 
 const ImageBlock = () => {
@@ -107,7 +106,7 @@ const Box = styled.div`
   align-items: center;
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.1);
-  background: ${COLORS.coumo_gray};
+  background: ${({ theme }) => theme.colors.coumo_gray};
 `;
 
 const MyText = styled.div`
@@ -118,18 +117,18 @@ const MyText = styled.div`
 
 const LargeP = styled.div`
   overflow: hidden;
-  color: ${COLORS.image_text};
+  color: ${({ theme }) => theme.colors.image_text};
   text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 18px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-style: normal;
   font-weight: 600;
   line-height: 170%; /* 34px */
 `;
 
 const SmallP = styled(LargeP)`
-  font-size: 13px;
+  font-size: ${({ theme }) => theme.fontSize.xs};
   font-weight: 500;
 `;
 
@@ -141,5 +140,5 @@ const PlusButton = styled.button`
   padding: 8px 12px;
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.1);
-  background: ${COLORS.coumo_gray};
+  background: ${({ theme }) => theme.colors.coumo_gray};
 `;

--- a/src/components/admin/shop/MenuMore.jsx
+++ b/src/components/admin/shop/MenuMore.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../styles/theme';
 import { SmallPlus } from '../../../assets';
 import Input from '../../common/Input';
 import RadioBtn from '../../common/RadioBtn';
@@ -155,8 +154,8 @@ const MenuTop = styled.div`
 `;
 
 const MenuTitle = styled.div`
-  color: ${COLORS.coumo_purple};
-  font-size: 19px;
+  color: ${({ theme }) => theme.colors.coumo_purple};
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 700;
   line-height: 170%; /* 31.68px */
@@ -170,11 +169,11 @@ const PlusButton = styled.button`
   align-items: center;
   border: none;
   border-radius: 42px;
-  background: ${COLORS.white_fff};
+  background: ${({ theme }) => theme.colors.white_fff};
   box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.25);
   color: #565656;
   text-align: center;
-  font-size: 14px;
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   font-weight: 600;
   line-height: 100%; /* 21.12px */
@@ -218,7 +217,7 @@ const Box = styled.div`
   align-items: center;
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.1);
-  background: ${COLORS.coumo_gray};
+  background: ${({ theme }) => theme.colors.coumo_gray};
 
   @media screen and (max-width: 1024px) {
     width: 220px;
@@ -234,27 +233,23 @@ const MyText = styled.div`
 
 const LargeP = styled.div`
   overflow: hidden;
-  color: ${COLORS.image_text};
+  color: ${({ theme }) => theme.colors.image_text};
   text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 16px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-style: normal;
   font-weight: 600;
   line-height: 170%; /* 34px */
 
   @media screen and (max-width: 1024px) {
-    font-size: 13px;
+    font-size: ${({ theme }) => theme.fontSize.sm};
   }
 `;
 
 const SmallP = styled(LargeP)`
-  font-size: 13px;
+  font-size: ${({ theme }) => theme.fontSize.xs};
   font-weight: 500;
-
-  @media screen and (max-width: 1024px) {
-    font-size: 10px;
-  }
 `;
 
 const InfoText = styled.div`
@@ -272,7 +267,7 @@ const Bottom = styled.div`
 `;
 
 const Span = styled.span`
-  color: ${COLORS.coumo_purple};
+  color: ${({ theme }) => theme.colors.coumo_purple};
 `;
 
 const StyledRadioBtn = styled(RadioBtn)`

--- a/src/components/admin/shop/workingHour/Dropdown.jsx
+++ b/src/components/admin/shop/workingHour/Dropdown.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../../styles/theme';
 import { IoIosArrowDown } from 'react-icons/io';
 import { timeData } from '../../../../assets/data/workingHourData';
 
@@ -67,20 +66,20 @@ const DropdownInput = styled.div`
   border-radius: 7px;
   font-weight: 400;
   font-family: 'Pretendard';
-  font-size: 12px;
+  font-size: ${({ theme }) => theme.fontSize.sm};
   box-sizing: border-box;
   padding: 0px 15px;
   cursor: pointer;
 
   pointer-events: ${(props) => (props.disabled ? 'none' : 'all')};
-  background-color: ${(props) =>
-    props.disabled ? '#e9e9e97e' : COLORS.coumo_gray};
+  background-color: ${({ theme, disabled }) =>
+    disabled ? '#e9e9e97e' : theme.colors.coumo_gray};
   color: ${(props) => (props.disabled ? '#dddddd' : '#666666')};
 
   @media screen and (max-width: 1024px) {
     width: 160px;
     height: 35px;
-    font-size: 11px;
+    font-size: ${({ theme }) => theme.fontSize.xs};
   }
 `;
 
@@ -97,7 +96,7 @@ const DropdownBox = styled.div`
   width: 100%;
   height: 200px;
   border-radius: 6px;
-  background-color: ${COLORS.coumo_gray};
+  background-color: ${({ theme }) => theme.colors.coumo_gray};
 
   display: flex;
   flex-direction: column;
@@ -112,7 +111,7 @@ const Item = styled.span`
   width: 100%;
   box-sizing: border-box;
   padding: 10px 20px;
-  font-size: 12px;
+  font-size: ${({ theme }) => theme.fontSize.sm};
   color: #333333;
   cursor: pointer;
 

--- a/src/components/admin/shop/workingHour/WorkingHour.jsx
+++ b/src/components/admin/shop/workingHour/WorkingHour.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../../../styles/theme';
 import Dropdown from './Dropdown';
 
 function WorkingHours({ day, setData }) {
@@ -41,11 +40,11 @@ const Container = styled.div`
 
 const Day = styled.h5`
   margin: 0;
-  font-size: 16px;
-  color: ${COLORS.coumo_purple};
+  font-size: ${({ theme }) => theme.fontSize.md};
+  color: ${({ theme }) => theme.colors.coumo_purple};
 
   @media screen and (max-width: 1024px) {
-    font-size: 14px;
+    font-size: ${({ theme }) => theme.fontSize.base};
   }
 `;
 
@@ -53,11 +52,12 @@ const DayOffButton = styled.button`
   width: 80px;
   height: 30px;
   border: none;
-  background-color: ${(props) =>
-    props.dayOff ? '#6746a6' : COLORS.coumo_gray};
-  color: ${(props) => (props.dayOff ? COLORS.white_fff : '#BABABA')};
+  background-color: ${({ theme, dayOff }) =>
+    dayOff ? '#6746a6' : theme.colors.coumo_gray};
+  color: ${({ theme, dayOff }) =>
+    dayOff ? theme.colors.white_fff : '#BABABA'};
   border-radius: 60px;
-  font-size: 12px;
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-weight: 600;
   cursor: pointer;
 `;

--- a/src/components/admin/writePost/Edit.jsx
+++ b/src/components/admin/writePost/Edit.jsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import Category from '../coupon/Category';
 import { writecategoryData } from '../../../assets/data/writecategoryData';
 import { StyledWriteInput } from '../../common/Input';
-import { COLORS } from '../../../styles/theme';
 import ImageBlock from '../shop/ImageBlock';
 
 const Edit = ({ category, setCategory, inputs, setInputs }) => {
@@ -77,9 +76,9 @@ const Representative = styled.div`
 `;
 
 const Label = styled.div`
-  color: ${COLORS.coumo_purple};
+  color: ${({ theme }) => theme.colors.coumo_purple};
   font-family: 'Pretendard';
-  font-size: 19px;
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 700;
   line-height: 132%; /* 31.68px */
@@ -88,8 +87,8 @@ const Label = styled.div`
 `;
 
 const Recommend = styled.div`
-  color: ${COLORS.coumo_purple};
-  font-size: 13px;
+  color: ${({ theme }) => theme.colors.coumo_purple};
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   font-weight: 400;
   line-height: 200%;
@@ -106,13 +105,13 @@ const StyledWriteTextarea = styled.textarea`
   gap: 8px;
   border-radius: 4px;
   border: none;
-  background: ${COLORS.coumo_gray};
+  background: ${({ theme }) => theme.colors.coumo_gray};
   overflow: hidden;
-  color: ${COLORS.text_gray};
+  color: ${({ theme }) => theme.colors.text_gray};
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: 'Pretendard';
-  font-size: 13px;
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   font-weight: 400;
   line-height: 170%; /* 27.2px */

--- a/src/components/common/AdminHeader.jsx
+++ b/src/components/common/AdminHeader.jsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Button from './Button';
-import { COLORS } from '../../styles/theme';
 import { Logo } from '../../assets';
 
 function AdminHeader() {
@@ -17,7 +16,7 @@ function AdminHeader() {
         </LogoContainer>
         <Button
           text={`${name} 사장님`}
-          color={COLORS.coumo_purple}
+          type={true}
           onClickBtn={() => {
             navigate('/mypage');
           }}
@@ -37,9 +36,9 @@ const Head = styled.div`
   justify-content: center;
 
   box-sizing: border-box;
-  background-color: ${COLORS.coumo_lightpurple};
+  background-color: ${({ theme }) => theme.colors.coumo_lightpurple};
   font-family: 'Pretendard';
-  font-size: 16px;
+  font-size: ${({ theme }) => theme.fontSize.md};
   position: absolute;
   top: 0;
   box-shadow: 0px 13px 21.8px 0px rgba(69, 0, 198, 0.08);

--- a/src/components/common/AdminVerticalHeader.jsx
+++ b/src/components/common/AdminVerticalHeader.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 import { Link, useLocation } from 'react-router-dom';
 
 function AdminVerticalHeader() {
@@ -135,7 +134,7 @@ const Menu = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  color: ${COLORS.text_darkgray};
+  color: ${({ theme }) => theme.colors.text_darkgray};
   padding-left: 40px;
   border-bottom: 1px solid lightgray;
   overflow: hidden;
@@ -146,7 +145,7 @@ const Menu = styled.div`
 
 const MenuTitle = styled.h5`
   margin: 0;
-  font-size: 16px;
+  font-size: ${({ theme }) => theme.fontSize.md};
 `;
 
 const SubMenu = styled.div`
@@ -159,9 +158,9 @@ const SubMenu = styled.div`
 const SubMenuLink = styled(Link)`
   width: 100%;
   box-sizing: border-box;
-  font-size: 14px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   text-decoration: none;
-  color: ${(props) =>
-    props.current ? COLORS.coumo_purple : COLORS.text_darkgray};
+  color: ${({ theme, current }) =>
+    current ? theme.colors.coumo_purple : theme.colors.text_darkgray};
   font-weight: 600;
 `;

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -1,21 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 
-const Button = ({
-  text,
-  onClickBtn,
-  color = COLORS.btn_lightgray,
-  disabled,
-  loading,
-}) => {
+const Button = ({ text, onClickBtn, type = false, disabled, loading }) => {
   return (
     <Btn
       title={text}
       onClick={onClickBtn}
       disabled={disabled || loading}
       loading={loading}
-      color={color}
+      type={type}
     >
       {loading ? 'Loading...' : text}
     </Btn>
@@ -34,23 +27,22 @@ export const Btn = styled.button`
   flex-shrink: 0;
   border: none;
   border-radius: 10px;
-  background: ${(props) => props.color};
-  color: ${(props) =>
-    props.color === COLORS.btn_lightgray
-      ? COLORS.text_btn_darkgray
-      : COLORS.white};
+  background: ${({ theme, type }) =>
+    type ? theme.colors.coumo_purple : theme.colors.btn_lightgray};
+  color: ${({ theme, type }) =>
+    type ? theme.colors.white : theme.colors.text_btn_darkgray};
   text-align: center;
-  font-size: 14px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-style: normal;
   font-weight: 700;
   line-height: 132%; /* 23.76px */
   letter-spacing: 0.54px;
 
   &:hover {
-    background: ${COLORS.btn_lightgray};
-    color: ${COLORS.text_btn_darkgray};
-    background: ${COLORS.coumo_purple};
-    color: ${COLORS.white};
+    background: ${({ theme }) => theme.colors.btn_lightgray};
+    color: ${({ theme }) => theme.colors.text_btn_darkgray};
+    background: ${({ theme }) => theme.colors.coumo_purple};
+    color: ${({ theme }) => theme.colors.white};
   }
 
   &::before {
@@ -58,7 +50,7 @@ export const Btn = styled.button`
   }
 
   @media screen and (max-width: 1024px) {
-    font-size: 12px;
+    font-size: ${({ theme }) => theme.fontSize.sm};
     padding: 8px 12px;
     height: 38px;
   }

--- a/src/components/common/FormPopUp.jsx
+++ b/src/components/common/FormPopUp.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 import Title from './Title';
 import { fadeIn } from '../../styles/GlobalStyle';
 
@@ -39,16 +38,16 @@ const Modal = styled.div`
   gap: 8px;
 
   border-radius: 12px;
-  background: ${COLORS.coumo_lightpurple};
+  background: ${({ theme }) => theme.colors.coumo_lightpurple};
 
   animation: ${fadeIn} 1s;
 
   & span {
     overflow: hidden;
-    color: ${COLORS.text_darkgray};
+    color: ${({ theme }) => theme.colors.text_darkgray};
     text-align: center;
     text-overflow: ellipsis;
-    font-size: 12px;
+    font-size: ${({ theme }) => theme.fontSize.sm};
     font-style: normal;
     font-weight: 300;
     line-height: 148%; /* 40.32px */

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 import { Logo } from '../../assets';
 import Button from './Button';
 
@@ -42,9 +41,9 @@ const Head = styled.div`
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
-  background-color: ${COLORS.white};
+  background-color: ${({ theme }) => theme.colors.white};
   font-family: 'Pretendard';
-  font-size: 16px;
+  font-size: ${({ theme }) => theme.fontSize.md};
   position: absolute;
   top: 0;
   box-shadow: 0px 13px 21.8px 0px rgba(69, 0, 198, 0.08);
@@ -73,7 +72,7 @@ const Nav = styled.div`
 `;
 
 const StyledLink = styled(Link)`
-  color: ${COLORS.text_darkgray};
+  color: ${({ theme }) => theme.colors.text_darkgray};
   font-weight: 600;
   text-decoration-line: none;
 `;

--- a/src/components/common/Input.jsx
+++ b/src/components/common/Input.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 
 const Input = ({
   label,
@@ -40,9 +39,9 @@ const Element = styled.div`
 `;
 
 const StyledInputTitle = styled.div`
-  color: ${COLORS.coumo_purple};
+  color: ${({ theme }) => theme.colors.coumo_purple};
   font-family: 'Pretendard';
-  font-size: 19px;
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 700;
   line-height: 132%; /* 31.68px */
@@ -50,7 +49,7 @@ const StyledInputTitle = styled.div`
   padding-bottom: 16px;
 
   @media screen and (max-width: 1024px) {
-    font-size: 16px;
+    font-size: ${({ theme }) => theme.fontSize.md};
   }
 `;
 
@@ -64,13 +63,13 @@ const StyledInput = styled.input`
   gap: 8px;
   border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.1);
-  background: ${COLORS.coumo_gray};
+  background: ${({ theme }) => theme.colors.coumo_gray};
   overflow: hidden;
-  color: ${COLORS.text_gray};
+  color: ${({ theme }) => theme.colors.text_gray};
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: 'Pretendard';
-  font-size: 13px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-style: normal;
   font-weight: 400;
   line-height: 170%; /* 27.2px */
@@ -80,7 +79,7 @@ const StyledInput = styled.input`
   }
 
   @media screen and (max-width: 1024px) {
-    font-size: 12px;
+    font-size: ${({ theme }) => theme.fontSize.sm};
     width: 80%;
     height: 20px;
   }

--- a/src/components/common/InputJoin.jsx
+++ b/src/components/common/InputJoin.jsx
@@ -72,7 +72,7 @@ const StyledInput = styled.input`
   color: #332f3c;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 16px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-style: normal;
   font-weight: 400;
   line-height: 170%; /* 32.3px */

--- a/src/components/common/RadioBtn.jsx
+++ b/src/components/common/RadioBtn.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 
 const RadioBtn = ({
   id,
@@ -43,7 +42,7 @@ const RadioLabel = styled.label`
   gap: 8px;
   flex-shrink: 0;
   border-radius: 5px;
-  background: ${COLORS.coumo_gray};
+  background: ${({ theme }) => theme.colors.coumo_gray};
   align-self: flex-end;
 
   @media screen and (max-width: 1024px) {
@@ -62,10 +61,10 @@ const RadioInput = styled.input`
   width: 1.3em;
   height: 1.3em;
   transition: border 0.5s ease-in-out;
-  background-color: ${COLORS.white};
+  background-color: ${({ theme }) => theme.colors.white};
 
   &:checked {
-    border: 0.67em solid ${COLORS.coumo_purple};
+    border: 0.67em solid ${({ theme }) => theme.colors.coumo_purple};
   }
 
   &:hover {
@@ -77,7 +76,7 @@ const RadioInput = styled.input`
     width: 1.1em;
     height: 1.1em;
     &:checked {
-      border: 0.57em solid ${COLORS.coumo_purple};
+      border: 0.57em solid ${({ theme }) => theme.colors.coumo_purple};
     }
     &:hover {
       box-shadow: 0 0 0 max(2px, 0.1em) lightgray;
@@ -91,12 +90,12 @@ const RadioSpan = styled.span`
   color: #545252;
   text-overflow: ellipsis;
   font-family: 'Pretendard';
-  font-size: ${(props) => (props.size === 110 ? '12.8px' : '12px')};
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   line-height: 170%; /* 27.2px */
   font-weight: ${(props) => (props.selected ? '600' : '400')};
 
   @media screen and (max-width: 1024px) {
-    font-size: ${(props) => (props.size === 110 ? '11.8px' : '11px')};
+    font-size: ${({ theme }) => theme.fontSize.xs};
   }
 `;

--- a/src/components/common/Tab.jsx
+++ b/src/components/common/Tab.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 
 const Tab = ({ text, tabKey }) => {
   const navigate = useNavigate();
@@ -42,10 +41,11 @@ const TabDiv = styled.div`
   gap: 8px;
   flex-shrink: 0;
   border-radius: 12px 12px 0px 0px;
-  background: ${(props) =>
-    props.selected ? COLORS.coumo_purple : COLORS.btn_lightgray};
-  color: ${(props) => (props.selected ? COLORS.white_fff : COLORS.tab_gray)};
-  font-size: 13px;
+  background: ${({ theme, selected }) =>
+    selected ? theme.colors.coumo_purple : theme.colors.btn_lightgray};
+  color: ${({ theme, selected }) =>
+    selected ? theme.colors.white_fff : theme.colors.tab_gray};
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-style: normal;
   font-weight: 700;
   line-height: 132%; /* 21.12px */

--- a/src/components/common/Title.jsx
+++ b/src/components/common/Title.jsx
@@ -1,21 +1,20 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
-const Title = ({ title, size = 19 }) => {
-  return <StyledTitle size={size}>{title}</StyledTitle>;
+const Title = ({ title }) => {
+  return <StyledTitle>{title}</StyledTitle>;
 };
 
 export default Title;
 
 const StyledTitle = styled.h1`
-  color: ${COLORS.coumo_purple};
-  font-size: ${(props) => props.size}px;
+  color: ${({ theme }) => theme.colors.coumo_purple};
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 700;
   line-height: 132%;
   margin: 0;
 
   @media screen and (max-width: 1024px) {
-    font-size: 16px;
+    font-size: ${({ theme }) => theme.fontSize.md};
   }
 `;

--- a/src/components/find/FindForm.jsx
+++ b/src/components/find/FindForm.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import { COLORS } from '../../styles/theme';
 import { Btn } from '../common/Button';
 import InputJoin from '../common/InputJoin';
 
@@ -132,7 +131,7 @@ const Title = styled.div`
   width: 890px;
   color: #333;
   text-align: center;
-  font-size: 36px;
+  font-size: ${({ theme }) => theme.fontSize.xl};
   font-style: normal;
   font-weight: 700;
   line-height: 100%;
@@ -148,17 +147,17 @@ const JoinBtn = styled.button`
   align-items: center;
   border: none;
   border-radius: 8px;
-  background: ${COLORS.coumo_purple};
-  color: ${COLORS.white};
+  background: ${({ theme }) => theme.colors.coumo_purple};
+  color: ${({ theme }) => theme.colors.white};
   text-align: center;
-  font-size: 20px;
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 700;
   margin-top: 60px;
 
   &:disabled {
-    background: ${COLORS.btn_lightgray};
-    color: ${COLORS.text_btn_darkgray};
+    background: ${({ theme }) => theme.colors.btn_lightgray};
+    color: ${({ theme }) => theme.colors.text_btn_darkgray};
   }
 `;
 
@@ -175,11 +174,11 @@ const NewButton = styled(Btn)`
   margin-top: 25px;
   margin-left: 10px;
   border-radius: 49px;
-  background-color: ${COLORS.coumo_purple};
+  background-color: ${({ theme }) => theme.colors.coumo_purple};
   text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 18px;
+  font-size: ${({ theme }) => theme.fontSize.md};
   font-style: normal;
   font-weight: 500;
   line-height: 170%;

--- a/src/components/home/Banner.jsx
+++ b/src/components/home/Banner.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 import { BannerIcon } from '../../assets';
 
 const Banner = () => {
@@ -29,7 +28,7 @@ export default Banner;
 const Back = styled.div`
   width: 100%;
   height: 735px;
-  background: ${COLORS.banner_gradient};
+  background: ${({ theme }) => theme.colors.banner_gradient};
 `;
 
 const Container = styled.div`
@@ -55,13 +54,13 @@ const Title = styled.h1`
   font-weight: 700;
   line-height: 140%;
   letter-spacing: 0.952px;
-  color: ${COLORS.white};
+  color: ${({ theme }) => theme.colors.white};
 `;
 
 const Description = styled.span`
   width: 100%;
   max-width: 503px;
-  color: ${COLORS.white};
+  color: ${({ theme }) => theme.colors.white};
   text-align: center;
   font-style: normal;
   font-weight: 300;
@@ -76,7 +75,6 @@ const Icon = styled.div`
   right: 70px;
 
   width: 30%;
-  /* height: 30%; */
   min-height: 300px;
   min-width: 300px;
   max-width: 430px;

--- a/src/components/home/Plan.jsx
+++ b/src/components/home/Plan.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 import { Arrow } from '../../assets';
 
 const Plan = ({ data }) => {
@@ -33,12 +32,12 @@ const Container = styled.div`
   align-items: center;
 
   border-radius: 12px;
-  background: ${COLORS.coumo_lightpurple};
+  background: ${({ theme }) => theme.colors.coumo_lightpurple};
 `;
 
 const Title = styled.h2`
   margin: 0;
-  color: ${COLORS.coumo_purple};
+  color: ${({ theme }) => theme.colors.coumo_purple};
   font-size: clamp(20px, 2vw, 25px);
   font-style: normal;
   font-weight: 800;
@@ -47,16 +46,16 @@ const Title = styled.h2`
 `;
 
 const Term = styled.span`
-  color: ${COLORS.text_black};
+  color: ${({ theme }) => theme.colors.text_black};
   text-align: center;
-  font-size: 15px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-style: normal;
   font-weight: 400;
   margin-bottom: 7px;
 `;
 
 const Price = styled.span`
-  color: ${COLORS.text_black};
+  color: ${({ theme }) => theme.colors.text_black};
   font-size: clamp(16px, 2vw, 22px);
   font-style: normal;
   font-weight: 700;

--- a/src/components/home/PricePlan.jsx
+++ b/src/components/home/PricePlan.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Plan from './Plan';
 import { priceData } from '../../assets/data/priceData';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 
 const PricePlan = () => {
   return (
@@ -29,9 +28,9 @@ const Container = styled.div`
 `;
 
 const Title = styled.h2`
-  color: ${COLORS.coumo_purple};
+  color: ${({ theme }) => theme.colors.coumo_purple};
   text-align: center;
-  font-size: 28px;
+  font-size: ${({ theme }) => theme.fontSize.xl};
   font-style: normal;
   font-weight: 800;
   line-height: 132%; /* 47.52px */

--- a/src/components/home/ServiceIntro.jsx
+++ b/src/components/home/ServiceIntro.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import TitleChip from './TitleChip';
-import { COLORS } from '../../styles/theme';
 
 const ServiceIntro = ({ data }) => {
   return (
@@ -34,7 +33,7 @@ const Content = styled.div`
 const Description = styled.span`
   color: #636166;
   text-align: center;
-  font-size: 22px;
+  font-size: ${({ theme }) => theme.fontSize.title};
   font-style: normal;
   font-weight: 300;
   line-height: 180%;
@@ -43,6 +42,6 @@ const Description = styled.span`
   white-space: pre-wrap;
 
   & strong {
-    color: ${COLORS.coumo_purple};
+    color: ${({ theme }) => theme.colors.coumo_purple};
   }
 `;

--- a/src/components/home/TitleChip.jsx
+++ b/src/components/home/TitleChip.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 
 const TitleChip = ({ title }) => {
   return <Container>{title}</Container>;
@@ -19,9 +18,9 @@ const Container = styled.span`
   border-radius: 89px;
   background: linear-gradient(331deg, #7733f9 20.34%, #e6d9ff 107.96%);
 
-  color: ${COLORS.white};
+  color: ${({ theme }) => theme.colors.white};
   text-align: center;
-  font-size: 20px;
+  font-size: ${({ theme }) => theme.fontSize.title};
   font-style: normal;
   font-weight: 600;
   line-height: 132%;

--- a/src/components/login/LoginBox.jsx
+++ b/src/components/login/LoginBox.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Btn } from '../common/Button';
-import { COLORS } from '../../styles/theme';
 import { LoginId, LoginPw, LoginSave, LoginSaveCheck } from '../../assets';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
@@ -111,7 +110,7 @@ const Box = styled.div`
 
   box-sizing: border-box;
   padding: 0 70px;
-  background: ${COLORS.white_fff};
+  background: ${({ theme }) => theme.colors.white_fff};
   box-shadow: 0px 8.978px 14.365px 0px rgba(68, 68, 68, 0.08);
 `;
 
@@ -135,20 +134,20 @@ const InputId = styled.input`
   align-items: flex-start;
   border-radius: 8px 8px 0px 0px;
   border: 1px solid #dadada;
-  color: ${COLORS.text_darkgray};
-  font-size: 16px;
+  color: ${({ theme }) => theme.colors.text_darkgray};
+  font-size: ${({ theme }) => theme.fontSize.md};
   font-style: normal;
   font-weight: 400;
   line-height: normal;
   letter-spacing: -0.629px;
 
   &::placeholder {
-    color: ${COLORS.text_lightgray};
+    color: ${({ theme }) => theme.colors.text_lightgray};
   }
 
   &:focus {
     outline: none;
-    border: 1px solid ${COLORS.coumo_purple};
+    border: 1px solid ${({ theme }) => theme.colors.coumo_purple};
   }
 `;
 
@@ -176,9 +175,9 @@ const Line = styled.div`
 `;
 
 const Text = styled.div`
-  color: ${COLORS.text_lightgray};
+  color: ${({ theme }) => theme.colors.text_lightgray};
   padding-left: 10px;
-  font-size: 14.015px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-style: normal;
   font-weight: 500;
   line-height: 26.738px; /* 190.788% */
@@ -187,16 +186,16 @@ const Text = styled.div`
 const LoginBtn = styled(Btn)`
   width: 100%;
   height: 48px;
-  padding-top: 20.27px;
-  padding-bottom: 21.73px;
-  background: ${COLORS.btn_lightgray};
-  color: ${COLORS.white_fff};
-  background: ${COLORS.coumo_purple};
-  color: ${COLORS.white};
+  padding-top: 20px;
+  padding-bottom: 21px;
+  background: ${({ theme }) => theme.colors.btn_lightgray};
+  color: ${({ theme }) => theme.colors.white_fff};
+  background: ${({ theme }) => theme.colors.coumo_purple};
+  color: ${({ theme }) => theme.colors.white};
 
   &:disabled {
-    background: ${COLORS.btn_lightgray};
-    color: ${COLORS.text_btn_darkgray};
+    background: ${({ theme }) => theme.colors.btn_lightgray};
+    color: ${({ theme }) => theme.colors.text_btn_darkgray};
   }
 `;
 
@@ -211,6 +210,6 @@ const More = styled.div`
   display: flex;
 
   &:hover {
-    color: ${COLORS.coumo_purple};
+    color: ${({ theme }) => theme.colors.coumo_purple};
   }
 `;

--- a/src/index.js
+++ b/src/index.js
@@ -6,14 +6,18 @@ import { Provider } from 'react-redux';
 import './styles/index.css';
 import { persistor, store } from './redux/store';
 import { PersistGate } from 'redux-persist/integration/react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from './styles/theme';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <Provider store={store}>
     <PersistGate loading={null} persistor={persistor}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <ThemeProvider theme={theme}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ThemeProvider>
     </PersistGate>
   </Provider>
 );

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../styles/theme';
 import Title from '../components/common/Title';
 import { CallIcon, DetailArrow, Line } from '../assets';
 import { useSelector } from 'react-redux';
@@ -78,7 +77,7 @@ const Content = styled.div`
 
   & h4 {
     margin: 0;
-    font-size: 20px;
+    font-size: ${({ theme }) => theme.fontSize.md};
     font-style: normal;
     font-weight: 600;
     line-height: normal;
@@ -125,7 +124,7 @@ const InfoLine = styled.div`
 
   & h5 {
     margin: 0;
-    font-size: 16px;
+    font-size: ${({ theme }) => theme.fontSize.base};
     font-style: normal;
     font-weight: 700;
     line-height: normal;
@@ -134,6 +133,7 @@ const InfoLine = styled.div`
 
   & span {
     width: 180px;
+    font-size: ${({ theme }) => theme.fontSize.base};
   }
 `;
 
@@ -148,7 +148,7 @@ const Box = styled.div`
   border-radius: 12px;
   background: #f5efff;
   color: #2f2a37;
-  font-size: 20px;
+  font-size: ${({ theme }) => theme.fontSize.md};
 
   & div {
     display: flex;

--- a/src/pages/coupon/AddCoupon.jsx
+++ b/src/pages/coupon/AddCoupon.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import Input from '../../components/common/Input';
 import Title from '../../components/common/Title';
-import { COLORS } from '../../styles/theme';
 import ColorPicker from '../../components/admin/coupon/ColorPicker';
 import StampCount from '../../components/admin/coupon/StampCount';
 import StampList from '../../components/admin/coupon/StampList';
@@ -107,7 +106,7 @@ const AddCoupon = () => {
         </DesginForm>
         <ButtonGroup>
           <Button text='취소하기' />
-          <Button text='쿠폰 만들기' color={COLORS.coumo_purple} />
+          <Button text='쿠폰 만들기' type={true} />
         </ButtonGroup>
       </DesignContainer>
     </Container>
@@ -118,7 +117,7 @@ export default AddCoupon;
 
 const Container = styled.div`
   width: 1200px;
-  font-size: 16px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   box-sizing: border-box;
   font-weight: 500;
   display: flex;
@@ -138,8 +137,8 @@ const TitleBar = styled.div`
   gap: 24px;
 
   & span {
-    color: ${COLORS.text_darkgray};
-    font-size: 14px;
+    color: ${({ theme }) => theme.colors.text_darkgray};
+    font-size: ${({ theme }) => theme.fontSize.base};
     font-style: normal;
     font-weight: 400;
     line-height: 132%;
@@ -165,15 +164,15 @@ const Step = styled.div`
 `;
 
 const StepName = styled.span`
-  color: ${COLORS.text_darkgray};
-  font-size: 19px;
+  color: ${({ theme }) => theme.colors.text_darkgray};
+  font-size: ${({ theme }) => theme.fontSize.md};
   font-style: normal;
   font-weight: 700;
   line-height: 132%;
   letter-spacing: 0.72px;
 
   & strong {
-    color: ${COLORS.coumo_purple};
+    color: ${({ theme }) => theme.colors.coumo_purple};
   }
 `;
 
@@ -248,8 +247,8 @@ const CouponContainer = styled.div`
 `;
 
 const Description = styled.span`
-  color: ${COLORS.text_darkgray};
-  font-size: 12px;
+  color: ${({ theme }) => theme.colors.text_darkgray};
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   font-weight: 300;
   line-height: 132%; /* 21.12px */

--- a/src/pages/coupon/UIServiceAd.jsx
+++ b/src/pages/coupon/UIServiceAd.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { COLORS } from '../../styles/theme';
 import styled from 'styled-components';
 import UIArticle from '../../assets/icon/UIArticle.svg';
 import ReasonCard from '../../components/admin/coupon/ReasonCard';
@@ -94,9 +93,9 @@ const Article = styled.div`
 `;
 
 const Big1 = styled.div`
-  color: ${COLORS.white_fefe};
-  text-shadow: 0px 4px 4.7px ${COLORS.text_shadow};
-  font-size: 36px;
+  color: ${({ theme }) => theme.colors.white_fefe};
+  text-shadow: 0px 4px 4.7px ${({ theme }) => theme.colors.text_shadow};
+  font-size: ${({ theme }) => theme.fontSize.xl};
   font-style: normal;
   font-weight: 700;
   line-height: 140%; /* 36px */
@@ -107,7 +106,7 @@ const Big1 = styled.div`
 const P = styled.p`
   padding-top: 50px;
   color: #27016f;
-  font-size: 18px;
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 600;
   line-height: 156%; /* 24.96px */
@@ -127,9 +126,9 @@ const WhiteButton = styled.button`
   flex-shrink: 0;
   border: none;
   border-radius: 8px;
-  background: ${COLORS.white_fff};
-  color: ${COLORS.coumo_purple};
-  font-size: 18px;
+  background: ${({ theme }) => theme.colors.white_fff};
+  color: ${({ theme }) => theme.colors.coumo_purple};
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 800;
   line-height: 30.6px; /* 170% */
@@ -155,7 +154,7 @@ const Step = styled.div`
 const Big2 = styled.div`
   color: #333;
   text-align: center;
-  font-size: 36px;
+  font-size: ${({ theme }) => theme.fontSize.xl};
   font-style: normal;
   font-weight: 700;
   line-height: 57.6px; /* 160% */
@@ -186,9 +185,9 @@ const Reason = styled.div`
 `;
 
 const Big3 = styled.div`
-  color: ${COLORS.coumo_purple};
-  font-family: 'Pretendard Variable';
-  font-size: 36px;
+  color: ${({ theme }) => theme.colors.coumo_purple};
+  font-family: 'Pretendard';
+  font-size: ${({ theme }) => theme.fontSize.xl};
   font-style: normal;
   font-weight: 700;
   line-height: 23.8px; /* 66.111% */
@@ -196,7 +195,7 @@ const Big3 = styled.div`
 `;
 
 const PGray = styled(P)`
-  color: ${COLORS.text_darkgray};
+  color: ${({ theme }) => theme.colors.text_darkgray};
   margin-right: 300px;
 `;
 
@@ -220,10 +219,10 @@ const PurpleButton = styled.button`
   flex-shrink: 0;
   border: none;
   border-radius: 18px;
-  background: ${COLORS.coumo_purple};
-  color: ${COLORS.white_fff};
+  background: ${({ theme }) => theme.colors.coumo_purple};
+  color: ${({ theme }) => theme.colors.white_fff};
   text-align: center;
-  font-size: 22px;
+  font-size: ${({ theme }) => theme.fontSize.title};
   font-style: normal;
   font-weight: 700;
   line-height: 100%; /* 32px */

--- a/src/pages/coupon/UIServiceForm.jsx
+++ b/src/pages/coupon/UIServiceForm.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { COLORS } from '../../styles/theme';
 import styled from 'styled-components';
 import Button from '../../components/common/Button';
 import Input from '../../components/common/Input';
@@ -99,11 +98,7 @@ const UIServiceForm = () => {
       </Description>
       <BtnContainer>
         <Button text='취소하기' />
-        <Button
-          text='신청서 제출하기'
-          color={COLORS.coumo_purple}
-          onClickBtn={onSubmit}
-        />
+        <Button text='신청서 제출하기' type={true} onClickBtn={onSubmit} />
       </BtnContainer>
       {popUp && (
         <FormPopUp
@@ -120,8 +115,8 @@ export default UIServiceForm;
 const Content = styled.div`
   width: 100%;
   height: auto;
-  color: ${COLORS.tab_gray};
-  font-size: 16px;
+  color: ${({ theme }) => theme.colors.tab_gray};
+  font-size: ${({ theme }) => theme.fontSize.base};
   box-sizing: border-box;
   font-weight: 500;
   position: relative;
@@ -132,8 +127,8 @@ const Content = styled.div`
 `;
 
 const Title = styled.h2`
-  color: ${COLORS.coumo_purple};
-  font-size: 19px;
+  color: ${({ theme }) => theme.colors.coumo_purple};
+  font-size: ${({ theme }) => theme.fontSize.title};
   font-style: normal;
   font-weight: 700;
   line-height: 132%; /* 31.68px */
@@ -153,10 +148,10 @@ const TextArea = styled.textarea`
   padding: 8px 12px;
   border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.1);
-  background: ${COLORS.coumo_gray};
+  background: ${({ theme }) => theme.colors.coumo_gray};
 
-  color: ${COLORS.text_gray};
-  font-size: 13px;
+  color: ${({ theme }) => theme.colors.text_gray};
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-style: normal;
   font-weight: 400;
   line-height: 170%; /* 27.2px */

--- a/src/pages/customer/CustomerManage.jsx
+++ b/src/pages/customer/CustomerManage.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Button from '../../components/common/Button';
-import { COLORS } from '../../styles/theme';
 import { LineLong } from '../../assets';
 import Title from '../../components/common/Title';
 import CustomerGroupButton from '../../components/admin/customer/customerManage/CustomerGroupButton';
@@ -86,7 +85,7 @@ const CustomerManage = () => {
           <Button
             text='필터 적용하기'
             onClickBtn={searchCustomer}
-            color={COLORS.coumo_purple}
+            type={true}
           />
         </ButtonContainer>
       </FormContainer>
@@ -197,15 +196,15 @@ const Wrapper = styled.div`
 `;
 
 const InputLabel = styled.span`
-  color: ${COLORS.coumo_purple};
-  font-size: 19px;
+  color: ${({ theme }) => theme.colors.coumo_purple};
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 700;
   line-height: 100%; /* 24px */
   letter-spacing: 0.72px;
 
   @media screen and (max-width: 1024px) {
-    font-size: 16px;
+    font-size: ${({ theme }) => theme.fontSize.md};
   }
 `;
 
@@ -225,7 +224,7 @@ const StyledInput = styled.input`
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: 'Pretendard';
-  font-size: 12px;
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   font-weight: 400;
   line-height: 170%; /* 27.2px */

--- a/src/pages/find/FoundId.jsx
+++ b/src/pages/find/FoundId.jsx
@@ -29,7 +29,7 @@ const Title = styled.div`
   width: 890px;
   color: #333;
   text-align: center;
-  font-size: 36px;
+  font-size: ${({ theme }) => theme.fontSize.title};
   font-style: normal;
   font-weight: 700;
   line-height: 100%;
@@ -48,5 +48,5 @@ const Text = styled.div`
   width: 100px;
   display: flex;
   flex-direction: row;
-  font-size: 36px;
+  font-size: ${({ theme }) => theme.fontSize.title};
 `;

--- a/src/pages/find/RePw.jsx
+++ b/src/pages/find/RePw.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 import InputJoin from '../../components/common/InputJoin';
 import FormPopUp from '../../components/common/FormPopUp';
 import axios from 'axios';
@@ -129,7 +128,7 @@ const Title = styled.div`
   width: 890px;
   color: #333;
   text-align: center;
-  font-size: 36px;
+  font-size: ${({ theme }) => theme.fontSize.title};
   font-style: normal;
   font-weight: 700;
   line-height: 100%; /* 36px */
@@ -139,7 +138,7 @@ const Title = styled.div`
 const Msg = styled.div`
   height: 15px;
   color: #fc0f0f;
-  font-size: 14px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-weight: 400;
   line-height: normal;
   letter-spacing: -0.3px;
@@ -159,16 +158,16 @@ const JoinBtn = styled.button`
   align-items: center;
   border: none;
   border-radius: 8px;
-  background: ${COLORS.coumo_purple};
-  color: ${COLORS.white};
+  background: ${({ theme }) => theme.colors.coumo_purple};
+  color: ${({ theme }) => theme.colors.white};
   text-align: center;
-  font-size: 20px;
+  font-size: ${({ theme }) => theme.fontSize.title};
   font-style: normal;
   font-weight: 700;
   margin-top: 30px;
 
   &:disabled {
-    background: ${COLORS.btn_lightgray};
-    color: ${COLORS.text_btn_darkgray};
+    background: ${({ theme }) => theme.colors.btn_lightgray};
+    color: ${({ theme }) => theme.colors.text_btn_darkgray};
   }
 `;

--- a/src/pages/join/Congratulate.jsx
+++ b/src/pages/join/Congratulate.jsx
@@ -38,7 +38,7 @@ const Card = styled.div`
 const Comment = styled.div`
   color: #333;
   text-align: center;
-  font-size: 36px;
+  font-size: ${({ theme }) => theme.fontSize.title};
   font-style: normal;
   font-weight: 700;
   line-height: 57.6px; /* 160% */
@@ -47,7 +47,7 @@ const Comment = styled.div`
 const LittleComment = styled.div`
   color: #212529;
   text-align: center;
-  font-size: 18px;
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 600;
   line-height: 32.4px; /* 180% */

--- a/src/pages/join/JoinOneStep.jsx
+++ b/src/pages/join/JoinOneStep.jsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { useNavigate } from 'react-router';
 import InputJoin from '../../components/common/InputJoin';
 import { CheckBoxDefault, CheckBoxSelected } from '../../assets';
-import { COLORS } from '../../styles/theme';
 import { Btn } from '../../components/common/Button';
 
 const JoinOneStep = () => {
@@ -202,7 +201,7 @@ const Title = styled.div`
   width: 890px;
   color: #333;
   text-align: center;
-  font-size: 36px;
+  font-size: ${({ theme }) => theme.fontSize.title};
   font-style: normal;
   font-weight: 700;
   line-height: 100%; /* 36px */
@@ -212,7 +211,7 @@ const Title = styled.div`
 const Msg = styled.div`
   height: 15px;
   color: #fc0f0f;
-  font-size: 14px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-weight: 400;
   line-height: normal;
   letter-spacing: -0.3px;
@@ -238,7 +237,7 @@ const Agree = styled.div`
 const CheckTitle = styled.div`
   color: #212529;
   text-align: center;
-  font-size: 18px;
+  font-size: ${({ theme }) => theme.fontSize.md};
   font-style: normal;
   font-weight: 600;
   line-height: 32.4px; /* 180% */
@@ -248,7 +247,7 @@ const CheckTitle = styled.div`
 const CheckMore = styled.div`
   color: rgba(33, 37, 41, 0.5);
   text-align: center;
-  font-size: 18px;
+  font-size: ${({ theme }) => theme.fontSize.md};
   font-style: normal;
   font-weight: 400;
   line-height: 32.4px; /* 180% */
@@ -265,17 +264,17 @@ const JoinBtn = styled.button`
   align-items: center;
   border: none;
   border-radius: 8px;
-  background: ${COLORS.coumo_purple};
-  color: ${COLORS.white};
+  background: ${({ theme }) => theme.colors.coumo_purple};
+  color: ${({ theme }) => theme.colors.white};
   text-align: center;
-  font-size: 20px;
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 700;
   margin-top: 30px;
 
   &:disabled {
-    background: ${COLORS.btn_lightgray};
-    color: ${COLORS.text_btn_darkgray};
+    background: ${({ theme }) => theme.colors.btn_lightgray};
+    color: ${({ theme }) => theme.colors.text_btn_darkgray};
   }
 `;
 
@@ -292,11 +291,11 @@ const NewButton = styled(Btn)`
   margin-top: 25px;
   margin-left: 15px;
   border-radius: 49px;
-  background-color: ${COLORS.coumo_purple};
+  background-color: ${({ theme }) => theme.colors.coumo_purple};
   text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 18px;
+  font-size: ${({ theme }) => theme.fontSize.md};
   font-style: normal;
   font-weight: 500;
   line-height: 170%; /* 30.6px */

--- a/src/pages/join/JoinTwoStep.jsx
+++ b/src/pages/join/JoinTwoStep.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 import { useNavigate, useLocation } from 'react-router';
 import InputJoin from '../../components/common/InputJoin';
 import { Btn } from '../../components/common/Button';
@@ -167,7 +166,7 @@ const Title = styled.div`
   width: 890px;
   color: #333;
   text-align: center;
-  font-size: 36px;
+  font-size: ${({ theme }) => theme.fontSize.title};
   font-style: normal;
   font-weight: 700;
   line-height: 100%; /* 36px */
@@ -183,17 +182,17 @@ const JoinBtn = styled.button`
   align-items: center;
   border: none;
   border-radius: 8px;
-  background: ${COLORS.coumo_purple};
-  color: ${COLORS.white};
+  background: ${({ theme }) => theme.colors.coumo_purple};
+  color: ${({ theme }) => theme.colors.white};
   text-align: center;
-  font-size: 20px;
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 700;
   margin-top: 50px;
 
   &:disabled {
-    background: ${COLORS.btn_lightgray};
-    color: ${COLORS.text_btn_darkgray};
+    background: ${({ theme }) => theme.colors.btn_lightgray};
+    color: ${({ theme }) => theme.colors.text_btn_darkgray};
   }
 `;
 
@@ -205,7 +204,7 @@ const Row = styled.div`
 const Msg = styled.div`
   height: 15px;
   color: #fc0f0f;
-  font-size: 14px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-weight: 400;
   line-height: normal;
   letter-spacing: -0.3px;
@@ -223,11 +222,11 @@ const NewButton = styled(Btn)`
   margin-top: 25px;
   margin-left: 15px;
   border-radius: 49px;
-  background-color: ${COLORS.coumo_purple};
+  background-color: ${({ theme }) => theme.colors.coumo_purple};
   text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 18px;
+  font-size: ${({ theme }) => theme.fontSize.md};
   font-style: normal;
   font-weight: 500;
   line-height: 170%; /* 30.6px */

--- a/src/pages/neighborhood/MyEdit.jsx
+++ b/src/pages/neighborhood/MyEdit.jsx
@@ -1,9 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Line } from '../../assets';
 import Title from '../../components/common/Title';
 import Button from '../../components/common/Button';
-import { COLORS } from '../../styles/theme';
 import { BtnContainer } from '../coupon/UIServiceForm';
 import FormPopUp from '../../components/common/FormPopUp';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
@@ -134,11 +133,7 @@ const MyEdit = () => {
       />
       <Btn>
         <Button text='삭제하기' onClickBtn={onDelete} />
-        <Button
-          text='수정완료'
-          color={COLORS.coumo_purple}
-          onClickBtn={onSubmit}
-        />
+        <Button text='수정완료' type={true} onClickBtn={onSubmit} />
       </Btn>
       {popUp && (
         <FormPopUp

--- a/src/pages/neighborhood/MyPostView.jsx
+++ b/src/pages/neighborhood/MyPostView.jsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { Line } from '../../assets';
 import Title from '../../components/common/Title';
 import Button from '../../components/common/Button';
-import { COLORS } from '../../styles/theme';
 import { BtnContainer } from '../coupon/UIServiceForm';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { getLabelByTag } from '../../assets/data/writecategoryData';
@@ -56,11 +55,7 @@ const MyPostView = () => {
       </div>
       <Btn>
         <Button text='취소하기' />
-        <Button
-          text='수정하기'
-          color={COLORS.coumo_purple}
-          onClickBtn={onClickMod}
-        />
+        <Button text='수정하기' type={true} onClickBtn={onClickMod} />
       </Btn>
     </StyledWrite>
   );
@@ -77,8 +72,8 @@ const StyledWrite = styled.div`
 `;
 
 const SubTitle = styled.h2`
-  color: ${COLORS.coumo_purple};
-  font-size: 19px;
+  color: ${({ theme }) => theme.colors.coumo_purple};
+  font-size: ${({ theme }) => theme.fontSize.lg};
   font-style: normal;
   font-weight: 700;
   line-height: 132%; /* 31.68px */
@@ -94,12 +89,12 @@ const TitleBox = styled.div`
 `;
 
 const Box = styled.div`
-  border: 1px solid ${COLORS.text_lightgray};
+  border: 1px solid ${({ theme }) => theme.colors.text_lightgray};
   border-radius: 5px;
   max-width: 900px;
   height: 400px;
   padding: 30px;
-  font-size: 14px;
+  font-size: ${({ theme }) => theme.fontSize.base};
 `;
 
 const Btn = styled(BtnContainer)`

--- a/src/pages/neighborhood/WritePost.jsx
+++ b/src/pages/neighborhood/WritePost.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import Button from '../../components/common/Button';
 import { BtnContainer } from '../coupon/UIServiceForm';
-import { COLORS } from '../../styles/theme';
 import FormPopUp from '../../components/common/FormPopUp';
 import Edit from '../../components/admin/writePost/Edit';
 
@@ -57,11 +56,7 @@ const WritePost = () => {
       />
       <Btn>
         <Button text='취소하기' onClickBtn={() => resetData()} />
-        <Button
-          text='저장하기'
-          color={COLORS.coumo_purple}
-          onClickBtn={() => onSubmit()}
-        />
+        <Button text='저장하기' typee={true} onClickBtn={() => onSubmit()} />
       </Btn>
       {popUp && (
         <FormPopUp

--- a/src/pages/shop/BasicInfo.jsx
+++ b/src/pages/shop/BasicInfo.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import Input from '../../components/common/Input';
-import { COLORS } from '../../styles/theme';
 import Category from '../../components/admin/coupon/Category';
 import Button from '../../components/common/Button';
 import { categoryData } from '../../assets/data/categoryData';
@@ -234,11 +233,7 @@ const BasicInfo = () => {
 
         <BtnContainer>
           <Button text='취소하기' />
-          <Button
-            text='저장하기'
-            color={COLORS.coumo_purple}
-            onClickBtn={onSubmit}
-          />
+          <Button text='저장하기' type={true} onClickBtn={onSubmit} />
         </BtnContainer>
       </Wrapper>
     </Content>
@@ -250,8 +245,8 @@ export default BasicInfo;
 const Content = styled.div`
   width: 100%;
   height: auto;
-  color: ${COLORS.tab_gray};
-  font-size: 16px;
+  color: ${({ theme }) => theme.colors.tab_gray};
+  font-size: ${({ theme }) => theme.fontSize.base};
   box-sizing: border-box;
   font-weight: 500;
   position: relative;

--- a/src/pages/shop/StoreInfo.jsx
+++ b/src/pages/shop/StoreInfo.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { COLORS } from '../../styles/theme';
 import ImageBlock from '../../components/admin/shop/ImageBlock';
 import MenuMore from '../../components/admin/shop/MenuMore';
 import Button from '../../components/common/Button';
@@ -29,11 +28,7 @@ const StoreInfo = () => {
       <MenuMore />
       <BtnContainer>
         <Button text='취소하기' />
-        <Button
-          text='저장하기'
-          color={COLORS.coumo_purple}
-          onClickBtn={onSubmit}
-        />
+        <Button text='저장하기' type={true} onClickBtn={onSubmit} />
       </BtnContainer>
     </Info>
   );
@@ -63,7 +58,7 @@ const Representative = styled.div`
 
 const Title = styled.div`
   width: 110px;
-  color: ${COLORS.coumo_purple};
+  color: ${({ theme }) => theme.colors.coumo_purple};
   font-size: 19px;
   font-style: normal;
   font-weight: 700;
@@ -72,8 +67,8 @@ const Title = styled.div`
 `;
 
 const Recommend = styled.div`
-  color: ${COLORS.coumo_purple};
-  font-size: 13px;
+  color: ${({ theme }) => theme.colors.coumo_purple};
+  font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
   font-weight: 400;
   line-height: 200%;
@@ -94,13 +89,13 @@ const DescripInput = styled.textarea`
   gap: 8px;
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.1);
-  background: ${COLORS.coumo_gray};
+  background: ${({ theme }) => theme.colors.coumo_gray};
   overflow: hidden;
-  color: ${COLORS.text_gray};
+  color: ${({ theme }) => theme.colors.text_gray};
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: 'Pretendard';
-  font-size: 14px;
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-style: normal;
   font-weight: 400;
   line-height: 170%; /* 27.2px */

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,4 +1,4 @@
-export const COLORS = {
+const colors = {
   banner_gradient: 'linear-gradient(331deg, #7733F9 6.83%, #E6D9FF 114.92%)',
   coumo_purple: '#7C43E8',
   coumo_lightpurple: '#EDE4FC',
@@ -17,4 +17,19 @@ export const COLORS = {
   card_lightpurple: '#f0ebff',
   text_shadow: '#6C31DB',
   image_text: '#7A7A7A',
+};
+
+const fontSize = {
+  xs: '10px',
+  sm: '12px',
+  base: '14px',
+  md: '16px',
+  lg: '18px',
+  title: '20px',
+  xl: '24px',
+};
+
+export const theme = {
+  colors,
+  fontSize,
 };


### PR DESCRIPTION
## 📍 작업 내용
ThemeProvider 적용 (폰트 사이즈 통일)

<br/>

## 📍 구현 결과 (선택)
<img width="1440" alt="스크린샷 2024-02-05 오후 1 31 44" src="https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/9f858ba9-b3cc-4ebb-b8f3-1b0a11ebfd31">


<br/>

## 📍 기타 사항
- `styles/theme.js` 에 폰트 사이즈, 컬러 정리되어 있습니다!
- Button 컴포넌트의 `type` 값을 true로 주면 쿠모보라색이 적용되고, false로 주면 기본 색상이 적용되도록 수정했습니다.
- 폰트 사이즈는 다 조정해두었는데 게시글, 메뉴 컴포넌트는 수정하실 때 조정해주시면 될 것 같아요!

사이즈명 | 사이즈
-- | --
xs | 10px
sm | 12px
base (기본) | 14px
md | 16px
lg | 18px
title | 20px
xl | 24px

<br/>
