### PR TITLE
[Style/#115]: 기본정보 페이지 반응형

### DIFF
--- a/src/components/admin/shop/workingHour/Dropdown.jsx
+++ b/src/components/admin/shop/workingHour/Dropdown.jsx
@@ -87,6 +87,10 @@ const DropdownInput = styled.div`
     height: 35px;
     font-size: ${({ theme }) => theme.fontSize.xs};
   }
+
+  @media screen and (max-width: 870px) {
+    width: 140px;
+  }
 `;
 
 const DropDownPosition = styled.div`
@@ -128,5 +132,9 @@ const Item = styled.span`
 
   &:hover {
     background-color: ${({ theme }) => theme.colors.coumo_lightpurple};
+  }
+
+  @media screen and (max-width: 1024px) {
+    font-size: ${({ theme }) => theme.fontSize.xs};
   }
 `;

--- a/src/components/common/Input.jsx
+++ b/src/components/common/Input.jsx
@@ -57,8 +57,9 @@ const StyledInputTitle = styled.div`
 const StyledInput = styled.input`
   display: flex;
   width: ${({ fullwidth }) => (fullwidth ? fullwidth : '100%')};
-  height: 25px;
+  height: 40px;
   padding: 8px 12px;
+  box-sizing: border-box;
   justify-content: flex-end;
   align-items: top;
   gap: 8px;
@@ -83,8 +84,8 @@ const StyledInput = styled.input`
 
   @media screen and (max-width: 1024px) {
     font-size: ${({ theme }) => theme.fontSize.sm};
-    width: 80%;
-    height: 20px;
+    width: 100%;
+    height: 35px;
   }
 `;
 

--- a/src/components/common/RadioBtn.jsx
+++ b/src/components/common/RadioBtn.jsx
@@ -49,7 +49,7 @@ const RadioLabel = styled.label`
   align-self: flex-end;
 
   @media screen and (max-width: 1024px) {
-    height: 40px;
+    height: 35px;
     width: 78px;
     padding-right: 15px;
     padding-left: 10px;

--- a/src/pages/coupon/AddCoupon.jsx
+++ b/src/pages/coupon/AddCoupon.jsx
@@ -109,11 +109,7 @@ const AddCoupon = () => {
         </DesginForm>
         <ButtonGroup>
           <Button text='취소하기' />
-          <Button
-            text='쿠폰 만들기'
-            color={COLORS.coumo_purple}
-            onClickBtn={registerCoupon}
-          />
+          <Button text='쿠폰 만들기' type={true} onClickBtn={registerCoupon} />
         </ButtonGroup>
       </DesignContainer>
     </Container>

--- a/src/pages/shop/BasicInfo.jsx
+++ b/src/pages/shop/BasicInfo.jsx
@@ -8,6 +8,7 @@ import DaumPostcode from 'react-daum-postcode';
 import { createRoot } from 'react-dom/client';
 import WorkingHour from '../../components/admin/shop/workingHour/WorkingHour';
 import axios from 'axios';
+import Title from '../../components/common/Title';
 
 const BasicInfo = () => {
   const [category, setCategory] = useState('cafe');
@@ -175,6 +176,7 @@ const BasicInfo = () => {
           columns='1fr 1fr 1fr'
         />
         <WorkingHours>
+          <Title title='영업시간' />
           {Object.keys(hours).map((day, i) => (
             <WorkingHour
               key={i}
@@ -253,13 +255,17 @@ const Content = styled.div`
   box-sizing: border-box;
   font-weight: 500;
   position: relative;
-  padding: 70px 0px;
+  padding: 70px 100px;
   display: flex;
-  justify-content: center;
+
+  @media screen and (max-width: 870px) {
+    padding: 70px 50px;
+  }
 `;
 
 const Wrapper = styled.div`
-  width: 75%;
+  width: 100%;
+  max-width: 900px;
   display: flex;
   flex-direction: column;
   gap: 50px;
@@ -268,7 +274,7 @@ const Wrapper = styled.div`
 const BtnContainer = styled.div`
   display: flex;
   gap: 16px;
-  justify-content: center;
+  justify-content: flex-end;
 `;
 
 const WorkingHours = styled.div`


### PR DESCRIPTION
## 📍 작업 내용
기본정보 페이지 반응형

<br/>

## 📍 구현 결과 (선택)
![화면 기록 2024-02-06 오전 11 39 44](https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/832a9bd0-8aeb-47f7-9d8b-709328a9172b)


<br/>

## 📍 기타 사항
- 페이지별 padding -> `70px 100px`로 통일하는 게 좋을 것 같습니다. (태블릿 세로 사이즈 반응형 구현시에는 `70px 50px`로!
- 내부 요소들을 wrapper로 한번 감싸고 max-width를 900px로 줬어요!
- 버튼도 오른쪽 하단에 고정시켰습니다

<br/>
