### PR TITLE
[Style/#143]: 쿠폰 UI 서비스 반응형

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,8 +29,10 @@ function App() {
     <>
       <GlobalStyle />
       {token ? (
-        <>
-          <AdminHeader />
+        <Column>
+          <Container>
+            <AdminHeader />
+          </Container>
           <Container>
             <AdminVerticalHeader />
             <AdminWrapper>
@@ -51,7 +53,7 @@ function App() {
               </Routes>
             </AdminWrapper>
           </Container>
-        </>
+        </Column>
       ) : (
         <>
           <Header />
@@ -76,9 +78,15 @@ function App() {
 
 export default App;
 
+const Column = styled.div`
+  width: 100vw;
+`;
+
 const Container = styled.div`
   display: flex;
+  flex-direction: row;
   width: 100vw;
+  /* justify-content: center; */
 `;
 
 const Wrapper = styled.div`

--- a/src/components/admin/coupon/CouponStep.jsx
+++ b/src/components/admin/coupon/CouponStep.jsx
@@ -6,7 +6,7 @@ const CouponStep = ({ id, step, description }) => {
     <Step>
       <Number>
         {id}
-        {id <= 4 && <Divider />}
+        {id <= 4 && <Divider id={id} />}
       </Number>
       <Title>{step}</Title>
       <Text>{description}</Text>
@@ -24,6 +24,10 @@ const Step = styled.div`
   width: 246px;
   gap: 8px;
   border-radius: 24px;
+
+  @media screen and (max-width: 1024px) {
+    width: 196px;
+  }
 `;
 
 const Number = styled.div`
@@ -42,6 +46,10 @@ const Number = styled.div`
   line-height: 23.8px; /* 170% */
   margin-top: 40px;
   position: relative;
+
+  @media screen and (max-width: 1024px) {
+    font-size: ${({ theme }) => theme.fontSize.sm};
+  }
 `;
 
 const Divider = styled.div`
@@ -53,6 +61,10 @@ const Divider = styled.div`
   background-color: ${({ theme }) => theme.colors.coumo_purple};
   transform: translateY(-50%);
   z-index: 0;
+
+  @media screen and (max-width: 1024px) {
+    opacity: 0;
+  }
 `;
 
 const Title = styled.div`
@@ -63,6 +75,11 @@ const Title = styled.div`
   font-weight: 700;
   line-height: 28px; /* 140% */
   margin-top: 10px;
+
+  @media screen and (max-width: 1024px) {
+    font-size: ${({ theme }) => theme.fontSize.md};
+    margin-top: 8px;
+  }
 `;
 
 const Text = styled.div`
@@ -74,4 +91,10 @@ const Text = styled.div`
   line-height: 28px; /* 175% */
   white-space: pre-line;
   margin-top: 10px;
+
+  @media screen and (max-width: 1024px) {
+    font-size: ${({ theme }) => theme.fontSize.sm};
+    line-height: 20px;
+    margin-top: 6px;
+  }
 `;

--- a/src/components/admin/coupon/CouponStep.jsx
+++ b/src/components/admin/coupon/CouponStep.jsx
@@ -62,7 +62,7 @@ const Divider = styled.div`
   transform: translateY(-50%);
   z-index: 0;
 
-  @media screen and (max-width: 1024px) {
+  @media screen and (max-width: 1600px) {
     opacity: 0;
   }
 `;

--- a/src/components/admin/coupon/ReasonCard.jsx
+++ b/src/components/admin/coupon/ReasonCard.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const ReasonCard = ({ id, img, title, description }) => {
+const ReasonCard = ({ id, img, title, description, style }) => {
   return (
-    <Card>
+    <Card style={style}>
       <CardImage>{img}</CardImage>
       <Reason>{title}</Reason>
       <Text>{description}</Text>
@@ -25,11 +25,32 @@ const Card = styled.div`
   background: ${({ theme }) => theme.colors.white};
   box-shadow: 12px 15px 14.8px 0px rgba(87, 76, 108, 0.1);
   backdrop-filter: blur(4px);
+
+  @media screen and (max-width: 1024px) {
+    width: 200px;
+    height: 250px;
+    padding: 16px;
+    gap: 4px;
+
+    &:hover {
+      z-index: 100;
+    }
+    &:not(:hover) {
+      filter: brightness(60%); /* 어둡게 만들기 */
+    }
+  }
 `;
 
 const CardImage = styled.div`
   width: 246px;
   height: 144px;
+
+  @media screen and (max-width: 1024px) {
+    svg {
+      width: 196px;
+      height: 115px;
+    }
+  }
 `;
 
 const Reason = styled.div`
@@ -41,10 +62,15 @@ const Reason = styled.div`
   line-height: 100%; /* 20px */
   letter-spacing: 0.2px;
   margin-top: 22px;
+
+  @media screen and (max-width: 1024px) {
+    font-size: ${({ theme }) => theme.fontSize.md};
+    margin-top: 15px;
+  }
 `;
 
 const Text = styled.div`
-  color: #635f6a;
+  color: ${({ theme }) => theme.colors.text};
   text-align: center;
   font-size: ${({ theme }) => theme.fontSize.base};
   font-style: normal;
@@ -53,4 +79,9 @@ const Text = styled.div`
   margin-top: 16px;
   white-space: pre-line;
   direction: initial;
+
+  @media screen and (max-width: 1024px) {
+    font-size: ${({ theme }) => theme.fontSize.sm};
+    margin-top: 7px;
+  }
 `;

--- a/src/components/admin/coupon/ReasonCard.jsx
+++ b/src/components/admin/coupon/ReasonCard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const ReasonCard = ({ id, img, title, description, style }) => {
+const ReasonCard = ({ img, title, description, style }) => {
   return (
     <Card style={style}>
       <CardImage>{img}</CardImage>

--- a/src/components/common/AdminHeader.jsx
+++ b/src/components/common/AdminHeader.jsx
@@ -30,7 +30,7 @@ function AdminHeader() {
 export default AdminHeader;
 
 const Head = styled.div`
-  width: 100%;
+  width: 100vw;
   height: 80px;
   display: flex;
   align-items: center;

--- a/src/pages/Coupon.jsx
+++ b/src/pages/Coupon.jsx
@@ -20,5 +20,7 @@ const Coupon = () => {
 export default Coupon;
 
 const Container = styled.div`
+  width: 100%;
   box-sizing: border-box;
+  overflow: hidden;
 `;

--- a/src/pages/coupon/UIServiceAd.jsx
+++ b/src/pages/coupon/UIServiceAd.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useEffect, useState } from 'react';
+import styled, { keyframes } from 'styled-components';
 import UIArticle from '../../assets/icon/UIArticle.svg';
 import ReasonCard from '../../components/admin/coupon/ReasonCard';
 import { reasonData } from '../../assets/data/reasonData';
@@ -69,7 +69,7 @@ const UIServiceAd = () => {
 export default UIServiceAd;
 
 const Content = styled.div`
-  width: 100vw;
+  width: 100%-250px;
   height: auto;
   display: flex;
   flex-direction: column;
@@ -90,6 +90,12 @@ const Article = styled.div`
   padding-left: 150px;
   box-sizing: border-box;
   margin: 0px;
+
+  @media screen and (max-width: 1024px) {
+    height: 600px;
+    padding-top: 96px;
+    padding-left: 120px;
+  }
 `;
 
 const Big1 = styled.div`
@@ -101,6 +107,10 @@ const Big1 = styled.div`
   line-height: 140%; /* 36px */
   gap: 10px;
   margin-bottom: 50px;
+
+  @media screen and (max-width: 1024px) {
+    font-size: ${({ theme }) => theme.fontSize.title};
+  }
 `;
 
 const P = styled.p`
@@ -113,6 +123,10 @@ const P = styled.p`
   letter-spacing: -0.32px;
   margin: 0px;
   padding: 0px;
+
+  @media screen and (max-width: 1024px) {
+    font-size: ${({ theme }) => theme.fontSize.md};
+  }
 `;
 
 const WhiteButton = styled.button`
@@ -138,10 +152,18 @@ const WhiteButton = styled.button`
     box-shadow: 12px 15px 12px 0px rgba(87, 76, 108, 0.5);
     backdrop-filter: blur(4px);
   }
+
+  @media screen and (max-width: 1024px) {
+    width: 140px;
+    height: 45px;
+    padding: 13px 15px 13px 15px;
+    font-size: ${({ theme }) => theme.fontSize.base};
+  }
 `;
 
 const Step = styled.div`
   width: 100%;
+  min-width: 1300px;
   height: 650px;
   display: flex;
   flex-direction: column;
@@ -149,6 +171,12 @@ const Step = styled.div`
   align-items: center;
   padding: 114px;
   box-sizing: border-box;
+
+  @media screen and (max-width: 1024px) {
+    min-width: 600px;
+    height: 900px;
+    font-size: ${({ theme }) => theme.fontSize.md};
+  }
 `;
 
 const Big2 = styled.div`
@@ -159,10 +187,18 @@ const Big2 = styled.div`
   font-weight: 700;
   line-height: 57.6px; /* 160% */
   margin-bottom: 10px;
+
+  @media screen and (max-width: 1024px) {
+    font-size: ${({ theme }) => theme.fontSize.title};
+  }
 `;
 
 const PBlack = styled(P)`
   color: #212529;
+
+  @media screen and (max-width: 1024px) {
+    font-size: ${({ theme }) => theme.fontSize.md};
+  }
 `;
 
 const CouponSteps = styled.div`
@@ -170,6 +206,15 @@ const CouponSteps = styled.div`
   gap: 20px;
   justify-content: space-around;
   margin-top: 40px;
+
+  @media screen and (max-width: 1024px) {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    > div:last-child {
+      grid-column: span 2;
+      justify-self: center;
+    }
+  }
 `;
 
 const Reason = styled.div`
@@ -182,9 +227,16 @@ const Reason = styled.div`
   height: 690px;
   padding: 150px;
   box-sizing: border-box;
+
+  @media screen and (max-width: 1024px) {
+    height: 600px;
+    padding-top: 96px;
+    padding-left: 120px;
+  }
 `;
 
 const Big3 = styled.div`
+  width: 400px;
   color: ${({ theme }) => theme.colors.coumo_purple};
   font-family: 'Pretendard';
   font-size: ${({ theme }) => theme.fontSize.xl};
@@ -192,11 +244,21 @@ const Big3 = styled.div`
   font-weight: 700;
   line-height: 23.8px; /* 66.111% */
   margin-bottom: 40px;
+
+  @media screen and (max-width: 1024px) {
+    font-size: ${({ theme }) => theme.fontSize.title};
+    margin-bottom: 20px;
+  }
 `;
 
 const PGray = styled(P)`
+  width: 400px;
   color: ${({ theme }) => theme.colors.text_darkgray};
   margin-right: 300px;
+
+  @media screen and (max-width: 1024px) {
+    font-size: ${({ theme }) => theme.fontSize.md};
+  }
 `;
 
 const Foot = styled.div`
@@ -218,7 +280,7 @@ const PurpleButton = styled.button`
   gap: 16px;
   flex-shrink: 0;
   border: none;
-  border-radius: 18px;
+  border-radius: 12px;
   background: ${({ theme }) => theme.colors.coumo_purple};
   color: ${({ theme }) => theme.colors.white};
   text-align: center;
@@ -233,6 +295,37 @@ const PurpleButton = styled.button`
     box-shadow: 10px 12px 10px 0px rgba(87, 76, 108, 0.5);
     backdrop-filter: blur(4px);
   }
+
+  @media screen and (max-width: 1024px) {
+    width: 200px;
+    height: 21px;
+    padding: 25px 20px;
+    font-size: ${({ theme }) => theme.fontSize.base};
+    margin-top: 20px;
+  }
+`;
+
+const slideInAnimation = keyframes`
+  0% {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+`;
+
+const fade = keyframes`
+  0% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
 `;
 
 const ReasonCardsContainer = styled.div`
@@ -240,6 +333,36 @@ const ReasonCardsContainer = styled.div`
   grid-template-columns: repeat(auto-fill, 270px);
   direction: rtl;
   box-sizing: border-box;
+  min-width: 1100px;
+
+  @media screen and (max-width: 1024px) {
+    min-width: 600px;
+    grid-template-columns: repeat(auto-fill, 100px);
+    direction: rtl;
+    margin-top: 30px;
+    gap: 30px;
+  }
+
+  // 순차적 애니메이션
+  > div {
+    animation: ${slideInAnimation} 0.5s ease forwards;
+    animation-delay: calc(1ms * var(--index));
+  }
+
+  & > * {
+    opacity: 0;
+    animation: ${fade} 3s linear infinite;
+  }
+
+  & > *:nth-child(1) {
+    animation-delay: 0s;
+  }
+  & > *:nth-child(2) {
+    animation-delay: 1.5s;
+  }
+  & > *:nth-child(3) {
+    animation-delay: 3s;
+  }
 `;
 
 const OverlappingReasonCard = styled(ReasonCard)`

--- a/src/pages/coupon/UIServiceAd.jsx
+++ b/src/pages/coupon/UIServiceAd.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import styled, { keyframes } from 'styled-components';
 import UIArticle from '../../assets/icon/UIArticle.svg';
 import ReasonCard from '../../components/admin/coupon/ReasonCard';
@@ -69,10 +69,12 @@ const UIServiceAd = () => {
 export default UIServiceAd;
 
 const Content = styled.div`
-  width: 100%-250px;
+  width: 100%;
+  min-width: 800px;
   height: auto;
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
   padding: 0px;
   margin: 0px;
 `;
@@ -163,7 +165,6 @@ const WhiteButton = styled.button`
 
 const Step = styled.div`
   width: 100%;
-  min-width: 1300px;
   height: 650px;
   display: flex;
   flex-direction: column;
@@ -172,8 +173,7 @@ const Step = styled.div`
   padding: 114px;
   box-sizing: border-box;
 
-  @media screen and (max-width: 1024px) {
-    min-width: 600px;
+  @media screen and (max-width: 1600px) {
     height: 900px;
     font-size: ${({ theme }) => theme.fontSize.md};
   }
@@ -194,7 +194,7 @@ const Big2 = styled.div`
 `;
 
 const PBlack = styled(P)`
-  color: #212529;
+  color: ${({ theme }) => theme.colors.text_black};
 
   @media screen and (max-width: 1024px) {
     font-size: ${({ theme }) => theme.fontSize.md};
@@ -207,7 +207,7 @@ const CouponSteps = styled.div`
   justify-content: space-around;
   margin-top: 40px;
 
-  @media screen and (max-width: 1024px) {
+  @media screen and (max-width: 1600px) {
     display: grid;
     grid-template-columns: 1fr 1fr;
     > div:last-child {
@@ -236,7 +236,7 @@ const Reason = styled.div`
 `;
 
 const Big3 = styled.div`
-  width: 400px;
+  width: 100%;
   color: ${({ theme }) => theme.colors.coumo_purple};
   font-family: 'Pretendard';
   font-size: ${({ theme }) => theme.fontSize.xl};
@@ -252,9 +252,9 @@ const Big3 = styled.div`
 `;
 
 const PGray = styled(P)`
-  width: 400px;
+  width: 250px;
+  width: 100%;
   color: ${({ theme }) => theme.colors.text_darkgray};
-  margin-right: 300px;
 
   @media screen and (max-width: 1024px) {
     font-size: ${({ theme }) => theme.fontSize.md};
@@ -333,11 +333,10 @@ const ReasonCardsContainer = styled.div`
   grid-template-columns: repeat(auto-fill, 270px);
   direction: rtl;
   box-sizing: border-box;
-  min-width: 1100px;
 
-  @media screen and (max-width: 1024px) {
-    min-width: 600px;
-    grid-template-columns: repeat(auto-fill, 100px);
+  @media screen and (max-width: 1600px) {
+    width: 100%;
+    grid-template-columns: repeat(3, 100px);
     direction: rtl;
     margin-top: 30px;
     gap: 30px;

--- a/src/pages/coupon/UIServiceForm.jsx
+++ b/src/pages/coupon/UIServiceForm.jsx
@@ -195,5 +195,5 @@ const TextArea = styled.textarea`
 export const BtnContainer = styled.div`
   display: flex;
   gap: 16px;
-  justify-content: center;
+  justify-content: flex-end;
 `;

--- a/src/pages/customer/CustomerManage.jsx
+++ b/src/pages/customer/CustomerManage.jsx
@@ -126,7 +126,7 @@ const FormContainer = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
-  border-bottom: 2px solid #d2d2d4;
+  border-bottom: 2px solid ${({ theme }) => theme.colors.line};
   padding: 70px 0px;
 
   @media screen and (max-width: 1024px) {

--- a/src/pages/neighborhood/MyPosts.jsx
+++ b/src/pages/neighborhood/MyPosts.jsx
@@ -169,6 +169,7 @@ const Container = styled.div`
   width: 100%;
   padding: 70px 100px;
   box-sizing: border-box;
+  overflow: hidden;
 
   @media screen and (max-width: 1024px) {
     padding: 70px 50px;

--- a/src/pages/neighborhood/WritePost.jsx
+++ b/src/pages/neighborhood/WritePost.jsx
@@ -87,6 +87,7 @@ const StyledWrite = styled.div`
   width: 100%;
   box-sizing: border-box;
   padding: 70px 100px;
+  overflow: hidden;
 
   @media screen and (max-width: 1024px) {
     padding: 70px 50px;

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -2,16 +2,20 @@ import { createGlobalStyle, keyframes } from 'styled-components';
 import '../assets/font/Font.css';
 
 const GlobalStyle = createGlobalStyle`
-  body {
+  html, body {
+    width: 100vw;
     margin: 0;
     font-family: "Pretendard";
     box-sizing: border-box;
-    padding-top: 80px;
     position: relative;
     
     &::-webkit-scrollbar {
       display: none;
     }
+  }
+
+  body {
+    padding-top: 80px;
   }
 `;
 


### PR DESCRIPTION
## 📍 작업 내용
쿠폰 UI 서비스 반응형

<br/>

## 📍 구현 결과 (선택)

https://github.com/UMC-5th-Coumo/Coumo_Web/assets/102593738/e275d79d-f7f9-4407-84d2-741813220981

<br/>

## 📍 기타 사항
- 개발자모드에서 width를 100%로 설정해도 계속 헤더 밖으로 내용이 튀어나온 이유가 cover로 되어 있는 배경이미지 때문에 헤더 밖으로 밀려나서 그런 거 같더라구요! 그래서 최상단에 있는 페이지에 `overflow: hidden;`를 넣어서 헤더 기준 width만 보이게 수정했습니다! (민님이 작업하신 부분은 따로 설정 안해도 문제 없어서, 제가 하는 부분만 그렇게 설정해 두었어요)
- 그리고 맨 아래 사장님 만족도 이야기 부분의 카드는 반응형(1024px 이하)으로 했을 때 모양은 그대로 유지하되 어둡게 바꾸어, hover 시에 카드가 밝게 보이도록 했어요! 웹에서는 hover가 테블릿에서는 클릭하면 보이는 것 같습니다.
(민님이 의견 주셨었는데 잘 기억이 안 나서 이렇게 해봤어요...😂 이후에 애니메이션 넣어서 자동으로 넘어가게 해도 좋을 것 같았습니다.)

<br/>
