### PR TITLE
[Fix/#152]: 팝업, 고객 데이터 배경색 수정

### DIFF
--- a/src/components/admin/coupon/ColorPicker.jsx
+++ b/src/components/admin/coupon/ColorPicker.jsx
@@ -45,7 +45,7 @@ const ColorBox = styled.button`
   padding: 8px 12px;
   align-items: center;
   gap: 8px;
-  border: 1px solid #d8d8d8;
+  border: 1px solid ${({ theme }) => theme.colors.text};
 
   color: ${({ theme }) => theme.colors.text_darkgray};
   text-overflow: ellipsis;
@@ -72,7 +72,6 @@ const Picker = styled.div`
 const Color = styled.div`
   width: 16px;
   height: 16px;
-  border: 0.5px solid lightgray;
   background-color: ${(props) => props.color};
 
   @media screen and (max-width: 1024px) {

--- a/src/components/admin/coupon/RadioButton.jsx
+++ b/src/components/admin/coupon/RadioButton.jsx
@@ -32,7 +32,7 @@ const RadioLabel = styled.label`
   background: ${({ theme }) => theme.colors.white};
   border: 1px solid
     ${({ theme, selected }) =>
-      selected ? theme.colors.coumo_purple : theme.colors.text_darkgray};
+      selected ? theme.colors.coumo_purple : theme.colors.text};
   cursor: pointer;
 
   @media screen and (max-width: 1024px) {

--- a/src/components/admin/coupon/Stamp.jsx
+++ b/src/components/admin/coupon/Stamp.jsx
@@ -33,7 +33,7 @@ const RadioLabel = styled.label`
     selected ? theme.colors.coumo_purple : theme.colors.white};
   color: ${({ theme, selected }) =>
     selected ? theme.colors.white : theme.colors.text};
-  border: 1px solid ${({ theme }) => theme.colors.btn_lightgray};
+  border: 1px solid ${({ theme }) => theme.colors.text};
   cursor: pointer;
 
   @media screen and (max-width: 1224px) {

--- a/src/components/admin/customer/customerManage/CustomerDetail.jsx
+++ b/src/components/admin/customer/customerManage/CustomerDetail.jsx
@@ -47,7 +47,7 @@ const Container = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: 16px;
-  background-color: ${({ theme }) => theme.colors.white_fff};
+  background-color: ${({ theme }) => theme.colors.white};
   border: 1px solid ${({ theme }) => theme.colors.coumo_purple};
   border-radius: 12px;
 

--- a/src/components/admin/customer/customerManage/CustomerList.jsx
+++ b/src/components/admin/customer/customerManage/CustomerList.jsx
@@ -56,7 +56,7 @@ const Wrapper = styled.div`
   border-radius: 10px;
   border: 1.5px solid #e3e1e8;
 
-  background-color: ${({ theme }) => theme.colors.white_fff};
+  background-color: ${({ theme }) => theme.colors.white};
 `;
 
 const Columns = styled.div`
@@ -102,10 +102,10 @@ const Customer = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.colors.line};
   cursor: pointer;
   background-color: ${({ theme, selected }) =>
-    selected ? theme.colors.card_lightpurple : theme.colors.white_fff};
+    selected ? theme.colors.coumo_lightpurple : theme.colors.white};
 
   &:hover {
-    background-color: ${({ theme }) => theme.colors.card_lightpurple};
+    background-color: ${({ theme }) => theme.colors.coumo_lightpurple};
   }
 
   padding-right: 15px;

--- a/src/components/admin/customer/customerManage/CustomerRadio.jsx
+++ b/src/components/admin/customer/customerManage/CustomerRadio.jsx
@@ -38,10 +38,10 @@ const RadioLabel = styled.label`
   gap: 8px;
   flex-shrink: 0;
   border-radius: 5px;
-  background: ${({ theme }) => theme.colors.white_fefe};
+  background: ${({ theme }) => theme.colors.white};
   border: 1px solid
     ${({ theme, isSelected }) =>
-      isSelected ? theme.colors.coumo_purple : theme.colors.tab_gray};
+      isSelected ? theme.colors.coumo_purple : theme.colors.text};
   align-self: flex-end;
 
   @media screen and (max-width: 1024px) {

--- a/src/components/common/popUp/OneBtnPopUp.jsx
+++ b/src/components/common/popUp/OneBtnPopUp.jsx
@@ -32,7 +32,7 @@ const Container = styled.div`
 const PopUp = styled.div`
   width: 380px;
   height: auto;
-  background-color: ${({ theme }) => theme.colors.white_fefe};
+  background-color: ${({ theme }) => theme.colors.white};
   border-radius: 12px;
 
   position: fixed;
@@ -63,7 +63,7 @@ const TextBox = styled.div`
 
   & span {
     font-size: ${({ theme }) => theme.fontSize.sm};
-    color: ${({ theme }) => theme.colors.text_gray};
+    color: ${({ theme }) => theme.colors.text};
   }
 
   @media screen and (max-width: 1024px) {

--- a/src/components/common/popUp/TwoBtnPopUp.jsx
+++ b/src/components/common/popUp/TwoBtnPopUp.jsx
@@ -38,7 +38,7 @@ const Container = styled.div`
 const PopUp = styled.div`
   width: 380px;
   height: auto;
-  background-color: ${({ theme }) => theme.colors.white_fefe};
+  background-color: ${({ theme }) => theme.colors.white};
   border-radius: 12px;
   z-index: 20;
 
@@ -68,7 +68,7 @@ const TextBox = styled.div`
 
   & span {
     font-size: ${({ theme }) => theme.fontSize.sm};
-    color: ${({ theme }) => theme.colors.text_gray};
+    color: ${({ theme }) => theme.colors.text};
   }
 
   @media screen and (max-width: 1024px) {

--- a/src/pages/customer/CustomerManage.jsx
+++ b/src/pages/customer/CustomerManage.jsx
@@ -221,10 +221,10 @@ const StyledInput = styled.input`
   justify-content: flex-end;
   align-items: center;
   border-radius: 7px;
-  background: ${({ theme }) => theme.colors.white_fefe};
+  background: ${({ theme }) => theme.colors.white};
   border: 1px solid
     ${({ theme, isEmpty }) =>
-      isEmpty ? theme.colors.tab_gray : theme.colors.coumo_purple};
+      isEmpty ? theme.colors.text : theme.colors.coumo_purple};
   overflow: hidden;
   color: #332f3c;
   text-overflow: ellipsis;


### PR DESCRIPTION
## 📍 작업 내용
팝업, 고객 데이터 배경색 수정

<br/>

## 📍 구현 결과 (선택)
<img width="531" alt="스크린샷 2024-02-11 오전 11 31 33" src="https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/979681b3-717d-4d01-9236-88931396ca3a">
<img width="1186" alt="스크린샷 2024-02-11 오전 11 31 44" src="https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/ffe5da25-efc3-4355-b8c6-fe26ddbaf859">


<br/>

## 📍 기타 사항

<br/>
