### PR TITLE
[API/#151]: 로그인 서버 연동

### DIFF
--- a/src/components/join/CheckButton.jsx
+++ b/src/components/join/CheckButton.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Btn } from '../common/Button';
 
 function CheckButton({ text, onClick }) {
-  return <NewButton>{text}</NewButton>;
+  return <NewButton onClick={onClick}>{text}</NewButton>;
 }
 
 export default CheckButton;

--- a/src/components/login/LoginBox.jsx
+++ b/src/components/login/LoginBox.jsx
@@ -4,7 +4,7 @@ import { Btn } from '../common/Button';
 import { LoginId, LoginPw, LoginSave, LoginSaveCheck } from '../../assets';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
-import { setUser } from '../../redux/slices/userSlice';
+import userSlice, { setUser } from '../../redux/slices/userSlice';
 import { defaultInstance } from '../../api/axios';
 
 const LoginBox = () => {
@@ -22,17 +22,6 @@ const LoginBox = () => {
   // useEffect(() => {}, []);
 
   const handleLoginClick = async () => {
-    // const userData = {
-    //   name: '강수빈',
-    //   email: 'admin123@gmail.com',
-    //   phone: '010-1234-1234',
-    //   id: 'admin123',
-    //   pw: 'admin123',
-    //   token: '1',
-    // };
-
-    // 리덕스에 저장
-    // dispatch(setUser(userData));
     try {
       const loginData = {
         loginId: id,
@@ -44,18 +33,26 @@ const LoginBox = () => {
 
       if (response.data.isSuccess) {
         console.log('로그인 성공', response.data);
-        // const { id, name, token } = response.data.result;
-        // localStorage.setItem('userToken', token);
+        const { ownerId, storeId, token, createdAt, write } =
+          response.data.result;
+        localStorage.setItem('userToken', token);
 
-        // dispatch(
-        //   setUser({
-        //     id: id,
-        //     pw: pw,
-        //     ownerId,
-        //     storeId,
-        //     token,
-        //   })
-        // );
+        dispatch(
+          setUser({
+            name: '유저',
+            email: 'test@gmail.com',
+            id: id,
+            pw: pw,
+            ownerId,
+            storeId,
+            token,
+            createdAt,
+            write, //false: 처음 로그인 유저, true: 기존 로그인 유저
+          })
+        );
+
+        console.log(userSlice);
+
         navigate('/');
       } else {
         console.error('로그인 실패');

--- a/src/components/login/LoginBox.jsx
+++ b/src/components/login/LoginBox.jsx
@@ -5,7 +5,7 @@ import { LoginId, LoginPw, LoginSave, LoginSaveCheck } from '../../assets';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { setUser } from '../../redux/slices/userSlice';
-import axios from 'axios';
+import { defaultInstance } from '../../api/axios';
 
 const LoginBox = () => {
   const [id, setId] = useState('');
@@ -22,20 +22,47 @@ const LoginBox = () => {
   // useEffect(() => {}, []);
 
   const handleLoginClick = async () => {
-    const userData = {
-      name: '강수빈',
-      email: 'admin123@gmail.com',
-      phone: '010-1234-1234',
-      id: 'admin123',
-      pw: 'admin123',
-      token: '1',
-    };
+    // const userData = {
+    //   name: '강수빈',
+    //   email: 'admin123@gmail.com',
+    //   phone: '010-1234-1234',
+    //   id: 'admin123',
+    //   pw: 'admin123',
+    //   token: '1',
+    // };
 
     // 리덕스에 저장
-    dispatch(setUser(userData));
+    // dispatch(setUser(userData));
+    try {
+      const loginData = {
+        loginId: id,
+        password: pw,
+      };
 
-    // 관리자 페이지로 redirect -> 일단 마이페이지로 랜딩
-    navigate('/mypage');
+      console.log('loginData', loginData);
+      const response = await defaultInstance.post('/owner/login', loginData);
+
+      if (response.data.isSuccess) {
+        console.log('로그인 성공', response.data);
+        // const { id, name, token } = response.data.result;
+        // localStorage.setItem('userToken', token);
+
+        // dispatch(
+        //   setUser({
+        //     id: id,
+        //     pw: pw,
+        //     ownerId,
+        //     storeId,
+        //     token,
+        //   })
+        // );
+        navigate('/');
+      } else {
+        console.error('로그인 실패');
+      }
+    } catch (error) {
+      console.error('Error Login');
+    }
   };
 
   const handleSaveClick = () => {

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 import Title from '../components/common/Title';
 import { CallIcon, DetailArrow } from '../assets';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import TwoBtnPopUp from '../components/common/popUp/TwoBtnPopUp';
 import { useNavigate } from 'react-router-dom';
 import ListBox from '../components/admin/myPage/ListBox';
+import { setUser } from '../redux/slices/userSlice';
 
 function MyPage() {
   const { name, id, email, phone } = useSelector((state) => state.user);
@@ -13,6 +14,7 @@ function MyPage() {
   const [withdrawal, setWithdrawal] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
   if (logOut || withdrawal) {
     document.body.style.overflow = 'hidden';
@@ -21,7 +23,12 @@ function MyPage() {
   }
 
   const handleLogOut = () => {
-    //
+    // dispatch(clearUser());
+    localStorage.removeItem('userToken');
+    dispatch(setUser(''));
+
+    // 로그아웃 후 로그인 페이지로 이동
+    navigate('/login');
   };
 
   const handleWithdrawal = () => {

--- a/src/pages/find/FindId.jsx
+++ b/src/pages/find/FindId.jsx
@@ -6,7 +6,7 @@ const FindId = () => {
     <FindForm
       title='아이디 찾기 (휴대폰 인증)'
       idLabel='사장님 성함'
-      serverEndpoint='/api/owner/findid'
+      serverEndpoint='/owner/verify-code'
       postData='name'
     />
   );

--- a/src/pages/join/JoinOneStep.jsx
+++ b/src/pages/join/JoinOneStep.jsx
@@ -116,6 +116,7 @@ const JoinOneStep = () => {
 
       if (response.data.isSuccess) {
         console.log('사용 가능');
+        setVaild((prev) => ({ ...prev, login: true }));
         setMsg({
           ...msg,
           login: (

--- a/src/pages/join/JoinOneStep.jsx
+++ b/src/pages/join/JoinOneStep.jsx
@@ -6,6 +6,7 @@ import CheckList from '../../components/join/CheckList';
 import JoinBtn from '../../components/join/JoinBtn';
 import ErrorMsg from '../../components/join/ErrorMsg';
 import CheckButton from '../../components/join/CheckButton';
+import { defaultInstance } from '../../api/axios';
 
 const JoinOneStep = () => {
   const navigate = useNavigate();
@@ -104,6 +105,32 @@ const JoinOneStep = () => {
     );
   };
 
+  /* ----- 중복 확안하기 ----- */
+  const handleCheckDup = async (e) => {
+    e.preventDefault();
+    try {
+      const response = await defaultInstance.post(
+        '/owner/join/check-login-id',
+        { loginId: account.id }
+      );
+
+      if (response.data.isSuccess) {
+        console.log('사용 가능');
+        setMsg({
+          ...msg,
+          login: (
+            <span style={{ color: '#33bd4a' }}>사용 가능한 아이디입니다.</span>
+          ),
+        });
+      } else {
+        console.log('사용 불가능');
+        setMsg({ ...msg, login: '이미 사용 중인 아이디입니다.' });
+      }
+    } catch (error) {
+      console.error('Error duplication:', error);
+    }
+  };
+
   /* ----- 다음으로 넘어가기 ----- */
   const onSubmit = (e) => {
     e.preventDefault();
@@ -127,7 +154,7 @@ const JoinOneStep = () => {
                 width='250px'
                 star={true}
               />
-              <CheckButton text='중복 확인하기' />
+              <CheckButton text='중복 확인하기' onClick={handleCheckDup} />
             </Row>
             <ErrorMsg text={msg.login} />
           </div>

--- a/src/pages/join/JoinTwoStep.jsx
+++ b/src/pages/join/JoinTwoStep.jsx
@@ -2,14 +2,17 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useNavigate, useLocation } from 'react-router';
 import InputJoin from '../../components/common/InputJoin';
-import axios from 'axios';
 import JoinBtn from '../../components/join/JoinBtn';
 import ErrorMsg from '../../components/join/ErrorMsg';
 import CheckButton from '../../components/join/CheckButton';
+import { defaultInstance } from '../../api/axios';
+import { useDispatch } from 'react-redux';
+// import { setUser } from '../../redux/slices/userSlice';
 
 const JoinTwoStep = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  // const dispatch = useDispatch();
 
   // 초기값
   const [info, setInfo] = useState({
@@ -89,18 +92,27 @@ const JoinTwoStep = () => {
           name: info.name,
           email: info.email,
           phone: info.phone,
-          // certified: info.certified,
         };
 
         console.log('joinData', joinData);
-        const response = await axios.post(
-          'https://dev.coumo.shop/owner/join',
-          joinData
-        );
-        // const userToken = localStorage.getItem('userToken');
+        const response = await defaultInstance.post('/owner/join', joinData);
 
         if (response.data.isSuccess) {
           console.log('회원가입 성공', response.data.result);
+          // const { ownerId, storeId, token } = response.data.result;
+          // 회원가입 성공 시 받은 정보를 Redux 스토어에 저장
+          // dispatch(
+          //   setUser({
+          //     name: info.name,
+          //     email: info.email,
+          //     phone: info.phone,
+          //     id: loginId,
+          //     pw: password,
+          //     ownerId,
+          //     storeId,
+          //     token,
+          //   })
+          // );
           navigate('/join/finish');
         } else {
           console.error('회원가입 실패');

--- a/src/redux/slices/userSlice.js
+++ b/src/redux/slices/userSlice.js
@@ -1,9 +1,9 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
-  // name: '',
-  // email: '',
-  // phone: '',
+  name: '',
+  email: '',
+  phone: '',
   id: '',
   pw: '',
   ownerId: '',
@@ -16,9 +16,9 @@ const userSlice = createSlice({
   initialState: initialState,
   reducers: {
     setUser: (state, action) => {
-      // state.name = action.payload.name;
-      // state.email = action.payload.email;
-      // state.phone = action.payload.phone;
+      state.name = action.payload.name;
+      state.email = action.payload.email;
+      state.phone = action.payload.phone;
       state.id = action.payload.id;
       state.pw = action.payload.pw;
       state.ownerId = action.payload.ownerId;
@@ -29,7 +29,7 @@ const userSlice = createSlice({
 });
 
 // actions
-export const { setUser } = userSlice.actions;
+export const { setUser, clearUser } = userSlice.actions;
 
 // reducer export
 export default userSlice.reducer;

--- a/src/redux/slices/userSlice.js
+++ b/src/redux/slices/userSlice.js
@@ -1,11 +1,13 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
-  name: '',
-  email: '',
-  phone: '',
+  // name: '',
+  // email: '',
+  // phone: '',
   id: '',
   pw: '',
+  ownerId: '',
+  storeId: '',
   token: '',
 };
 
@@ -14,11 +16,13 @@ const userSlice = createSlice({
   initialState: initialState,
   reducers: {
     setUser: (state, action) => {
-      state.name = action.payload.name;
-      state.email = action.payload.email;
-      state.phone = action.payload.phone;
+      // state.name = action.payload.name;
+      // state.email = action.payload.email;
+      // state.phone = action.payload.phone;
       state.id = action.payload.id;
       state.pw = action.payload.pw;
+      state.ownerId = action.payload.ownerId;
+      state.storeId = action.payload.storeId;
       state.token = action.payload.token;
     },
   },


### PR DESCRIPTION
## 📍 작업 내용
회원가입 (인증 포함), 로그인 (중복확인, 인증 포함), 아이디 찾기 (인증) 서버 연동 완료
*비밀번호 쪽은 아직 구현이 안 되었고, 아이디 찾기는 인증번호 전송까지는 되는데, 인증 확인에서 500 에러 떠러 서버 측에서 조금 더 봐주셔야 할 것 같습니다!

<br/>

## 📍 구현 결과 (선택)

https://github.com/UMC-5th-Coumo/Coumo_Web/assets/102593738/09ddab1c-553f-469a-add5-f3ae5a3fb696



<br/>

## 📍 기타 사항
- 영상에서 회원가입 단계 중 인증확인 안 되었는데 확인버튼 disable 풀리는 거 수정했습니다!
- 로그인 시에 name과 email은 제가 임시로 넣어두었습니다! email은 필요없을 것 같은데 name은 오른쪽 상단에 나와야 하기 때문에 서버 측에 로그인시 name도 같이 보내주실 수 있는지 여쭤보겠습니다:)
- 로그인 하실 때 `id: test123`, `pw: testtest1!` 로 하시면 돼요👍🏻

<br/>
![image](https://github.com/UMC-5th-Coumo/Coumo_Web/assets/102593738/6e200140-05db-47da-8214-be4ddbebe39d)

<br/>
