### PR TITLE
[Style/#202]: 매장 설명 페이지 디자인 수정

### DIFF
--- a/src/assets/data/chartOptions.js
+++ b/src/assets/data/chartOptions.js
@@ -7,18 +7,20 @@ export const barChartoption = {
     legend: {
       display: false,
     },
+    tooltip: {
+      intersect: false,
+      position: 'nearest',
+      displayColors: false,
+      bodySpacing: 5, // 툴팁 내부 항목들 간 간격
+      bodyFont: {
+        font: {
+          family: 'Pretendard',
+        },
+      },
+    },
   },
   interaction: {
     mode: 'index',
-  },
-  tooltip: {
-    // 툴팁 스타일링
-    bodySpacing: 5, // 툴팁 내부 항목들 간 간격
-    bodyFont: {
-      font: {
-        family: 'Pretendard',
-      },
-    },
   },
   scales: {
     x: {
@@ -30,6 +32,7 @@ export const barChartoption = {
       grid: {
         display: false,
       },
+      beginAtZero: true,
     },
   },
   barThickness: 25,
@@ -44,18 +47,20 @@ export const smallBarChartoption = {
     legend: {
       display: false,
     },
+    tooltip: {
+      intersect: false,
+      displayColors: false,
+      position: 'nearest',
+      bodySpacing: 5, // 툴팁 내부 항목들 간 간격
+      bodyFont: {
+        font: {
+          family: 'Pretendard',
+        },
+      },
+    },
   },
   interaction: {
     mode: 'index',
-  },
-  tooltip: {
-    // 툴팁 스타일링
-    bodySpacing: 5, // 툴팁 내부 항목들 간 간격
-    bodyFont: {
-      font: {
-        family: 'Pretendard',
-      },
-    },
   },
   scales: {
     x: {
@@ -67,6 +72,7 @@ export const smallBarChartoption = {
       grid: {
         display: false,
       },
+      beginAtZero: true,
     },
   },
   barThickness: 20,
@@ -81,18 +87,20 @@ export const lightBarChartoption = {
     legend: {
       display: false,
     },
+    tooltip: {
+      intersect: false,
+      displayColors: false,
+      position: 'nearest',
+      bodySpacing: 5, // 툴팁 내부 항목들 간 간격
+      bodyFont: {
+        font: {
+          family: 'Pretendard',
+        },
+      },
+    },
   },
   interaction: {
     mode: 'index',
-  },
-  tooltip: {
-    // 툴팁 스타일링
-    bodySpacing: 5, // 툴팁 내부 항목들 간 간격
-    bodyFont: {
-      font: {
-        family: 'Pretendard',
-      },
-    },
   },
   scales: {
     x: {
@@ -104,6 +112,7 @@ export const lightBarChartoption = {
       grid: {
         display: false,
       },
+      beginAtZero: true,
     },
   },
   barThickness: 15,
@@ -120,16 +129,19 @@ export const lineChartOption = {
     title: {
       display: false,
     },
-  },
-  tooltip: {
-    // 툴팁 스타일링
-    bodySpacing: 1, // 툴팁 내부 항목들 간 간격
-    bodyFont: {
-      font: {
-        family: 'Pretendard',
+    tooltip: {
+      intersect: false,
+      displayColors: false,
+      position: 'nearest',
+      bodySpacing: 1, // 툴팁 내부 항목들 간 간격
+      bodyFont: {
+        font: {
+          family: 'Pretendard',
+        },
       },
     },
   },
+
   scales: {
     x: {
       grid: {
@@ -140,6 +152,7 @@ export const lineChartOption = {
       grid: {
         display: false,
       },
+      beginAtZero: true,
     },
   },
 };
@@ -151,15 +164,16 @@ export const doughnutChartOption = {
     legend: {
       display: false,
     },
-  },
-  tooltip: {
-    // 툴팁 스타일링
-    bodySpacing: 5, // 툴팁 내부 항목들 간 간격
-    bodyFont: {
-      font: {
-        family: 'Pretendard',
+    tooltip: {
+      // 툴팁 스타일링
+      bodySpacing: 5, // 툴팁 내부 항목들 간 간격
+      bodyFont: {
+        font: {
+          family: 'Pretendard',
+        },
       },
     },
   },
+
   cutout: 60,
 };

--- a/src/components/admin/shop/ImageBlock.jsx
+++ b/src/components/admin/shop/ImageBlock.jsx
@@ -158,6 +158,7 @@ const ImagePreview = styled.img`
   object-fit: cover;
   border-radius: 8px;
   margin-top: 15px;
+  cursor: pointer;
 `;
 
 const Image = styled.div`
@@ -173,13 +174,12 @@ const Scroll = styled.div`
   flex-direction: row;
   gap: 20px;
   overflow-x: auto;
-  height: 280px;
 `;
 
 const Box = styled.div`
   display: flex;
-  width: 275px;
-  height: 257px;
+  width: 230px;
+  height: 215px;
   box-sizing: border-box;
   justify-content: flex-end;
   align-items: center;
@@ -190,8 +190,8 @@ const Box = styled.div`
 
 const InnerBox = styled.div`
   display: flex;
-  width: 275px;
-  height: 257px;
+  width: 230px;
+  height: 215px;
   align-items: center;
   justify-content: center;
   position: relative;
@@ -230,15 +230,26 @@ const StyledCancel = styled.div`
   right: 10px;
   z-index: 100;
   align-items: center;
+  cursor: pointer;
 `;
 
 const PlusButton = styled.button`
   flex: 0 0 auto;
   overflow: hidden;
-  width: 275px;
-  height: 257px;
+  width: 230px;
+  height: 215px;
   padding: 8px 12px;
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: ${({ theme }) => theme.colors.lightpurple};
+
+  & svg {
+    width: 50px;
+    height: 50px;
+    cursor: pointer;
+    &:hover {
+      scale: calc(1.07);
+      transition: scale 0.2s ease-in-out;
+    }
+  }
 `;

--- a/src/components/admin/shop/MenuMore.jsx
+++ b/src/components/admin/shop/MenuMore.jsx
@@ -141,7 +141,7 @@ const MenuMore = ({ onChange }) => {
                   label='상품명'
                   fullwidth='180px'
                   fullheight='32px'
-                  fontSize
+                  fontSize='18px'
                   paddingB='7px'
                   paddingL='2px'
                   onChange={(event) => handleProductNameChange(event, index)}
@@ -151,7 +151,7 @@ const MenuMore = ({ onChange }) => {
                   label='상품 가격'
                   fullwidth='180px'
                   fullheight='32px'
-                  fontSize
+                  fontSize='18px'
                   paddingB='7px'
                   paddingL='2px'
                   onChange={(event) => handlePriceInfoChange(event, index)}
@@ -208,11 +208,10 @@ const PlusButton = styled.button`
   padding: 8px 50px 7px 50px;
   justify-content: center;
   align-items: center;
-  border: none;
+  border: 1px solid ${({ theme }) => theme.colors.lightpurple_border};
   border-radius: 42px;
   background: ${({ theme }) => theme.colors.white};
-  box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.25);
-  color: #565656;
+  color: ${({ theme }) => theme.colors.text_darkgray};
   text-align: center;
   font-size: ${({ theme }) => theme.fontSize.sm};
   font-style: normal;
@@ -220,6 +219,7 @@ const PlusButton = styled.button`
   line-height: 100%; /* 21.12px */
   letter-spacing: 0.48px;
   gap: 15px;
+  cursor: pointer;
 
   @media screen and (max-width: 768px) {
     padding: 8px 30px 7px 30px;
@@ -257,7 +257,7 @@ const Box = styled.div`
   align-items: center;
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.1);
-  background: ${({ theme }) => theme.colors.coumo_lightpurple};
+  background: ${({ theme }) => theme.colors.lightpurple};
 `;
 
 const InnerBox = styled.div`
@@ -266,6 +266,7 @@ const InnerBox = styled.div`
   height: 190px;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
 `;
 
 const MyText = styled(Column)`
@@ -305,6 +306,10 @@ const Bar = styled(Row)`
   align-items: center;
   margin-top: 8px;
   margin-bottom: 5px;
+
+  & svg {
+    cursor: pointer;
+  }
 `;
 
 const Content = styled(Column)`
@@ -316,8 +321,9 @@ export const Span = styled.span`
 `;
 
 const NewBtn = styled.span`
-  width: 35px;
-  height: 20px;
+  width: 40px;
+  height: 22px;
+  cursor: pointer;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/pages/shop/StoreInfo.jsx
+++ b/src/pages/shop/StoreInfo.jsx
@@ -39,7 +39,7 @@ const StoreInfo = () => {
       <Image>
         <Representative>
           <Title>대표이미지</Title>
-          <Recommend>*이미지는 1000px, 1000px의 1:1비율을 권장합니다</Recommend>
+          <Recommend>*이미지는 1:1비율을 권장합니다</Recommend>
         </Representative>
         <ImageBlock onChange={handleImageChange} />
       </Image>
@@ -59,7 +59,6 @@ const StoreInfo = () => {
         <MenuMore onChange={handleMenuChange} />
       </Scroll>
       <BtnContainer>
-        <Button text='취소하기' />
         <Button text='저장하기' type={true} onClickBtn={onSubmit} />
       </BtnContainer>
     </Info>
@@ -75,7 +74,7 @@ const Info = styled.div`
   display: flex;
   flex-direction: column;
   padding: 70px 100px;
-  gap: 100px;
+  gap: 80px;
   box-sizing: border-box;
 
   @media screen and (max-width: 1024px) {
@@ -91,8 +90,6 @@ const Image = styled.div`
 const Representative = styled.div`
   width: 500px;
   display: flex;
-  flex-direction: row;
-  gap: 30px;
   margin-bottom: 20px;
 `;
 
@@ -158,8 +155,8 @@ const DescripInput = styled.textarea`
 `;
 
 const BtnContainer = styled.div`
-  max-width: 950px;
+  width: 100%;
   display: flex;
   gap: 16px;
-  justify-content: right;
+  justify-content: center;
 `;


### PR DESCRIPTION
## 📍 작업 내용
- 이미지 박스 크기 조절
- 매장설명 페이지 내 gap 조절
- 그래프 tooltip 조정

<br/>

## 📍 구현 결과 (선택)
<img width="1440" alt="스크린샷 2024-02-14 오후 2 05 00" src="https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/4bc3252e-e4d1-4815-8a2f-5e16aa5b5e88"><br/>

![화면 기록 2024-02-14 오후 2 05 23](https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/f47dffef-7f68-4bae-9554-97fc9cc69488)


<br/>

## 📍 기타 사항
그래프 툴팁 맨 위에 뜨도록하고 그래프 근처에만 가도 툴팁이 뜨도록 수정했습니다!

<br/>
