### PR TITLE
[Fix/#240]: 매장관리 > 기본정보 redux 연동 오류 수정

### DIFF
--- a/src/assets/data/categoryData.js
+++ b/src/assets/data/categoryData.js
@@ -64,3 +64,8 @@ export const getLabelByTag = (tag) => {
   const category = writecategoryData.find((item) => item.id === tag);
   return category ? category.label : null;
 };
+
+export const getLabelByCategoryId = (tag) => {
+  const category = categoryData.find((item) => item.id === tag);
+  return category ? category.label : null;
+};

--- a/src/components/admin/home/StoreInfo.jsx
+++ b/src/components/admin/home/StoreInfo.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 import { BiStore } from 'react-icons/bi';
+import { useSelector } from 'react-redux';
+import { getLabelByCategoryId } from '../../../assets/data/categoryData';
 
 function StoreInfo() {
+  const { info } = useSelector((state) => state.store);
   return (
     <Container>
       <Title>
@@ -12,19 +15,19 @@ function StoreInfo() {
       <InfoContainer>
         <InfoLine>
           <h5>매장명</h5>
-          <span>쿠모</span>
+          <span>{info.storeName}</span>
         </InfoLine>
         <InfoLine>
           <h5>카테고리</h5>
-          <span>카페</span>
+          <span>{getLabelByCategoryId(info.category)}</span>
         </InfoLine>
         <InfoLine>
           <h5>매장 번호</h5>
-          <span>010-1234-1234</span>
+          <span>{info.number}</span>
         </InfoLine>
         <InfoLine>
           <h5>매장 주소</h5>
-          <span>서울특별시 마포구 어쩌고 저쩌고 어쩌고 저쩌고,,</span>
+          <span>{info.address + ' ' + info.addressDetail}</span>
         </InfoLine>
       </InfoContainer>
     </Container>

--- a/src/components/admin/home/WorkingHours.jsx
+++ b/src/components/admin/home/WorkingHours.jsx
@@ -1,8 +1,33 @@
 import React from 'react';
 import styled from 'styled-components';
 import { LuClock4 } from 'react-icons/lu';
+import { useSelector } from 'react-redux';
 
 function WorkingHours() {
+  const {
+    info: { workingHours },
+  } = useSelector((state) => state.store);
+
+  const convertToDay = (id) => {
+    switch (id) {
+      case 'MONDAY':
+        return '월';
+      case 'TUESDAY':
+        return '화';
+      case 'WEDNESDAY':
+        return '수';
+      case 'THURSDAY':
+        return '목';
+      case 'FRIDAY':
+        return '금';
+      case 'SATURDAY':
+        return '토';
+      case 'SUNDAY':
+        return '일';
+      default:
+        return;
+    }
+  };
   return (
     <Container>
       <Title>
@@ -10,34 +35,20 @@ function WorkingHours() {
         영업 시간
       </Title>
       <HoursWrapper>
-        <Hour>
-          <h5>월</h5>
-          <span>휴무</span>
-        </Hour>
-        <Hour>
-          <h5>화</h5>
-          <span>10:00 ~ 9:00</span>
-        </Hour>
-        <Hour>
-          <h5>수</h5>
-          <span>10:00 ~ 9:00</span>
-        </Hour>
-        <Hour>
-          <h5>목</h5>
-          <span>휴무</span>
-        </Hour>
-        <Hour>
-          <h5>금</h5>
-          <span>10:00 ~ 9:00</span>
-        </Hour>
-        <Hour>
-          <h5>토</h5>
-          <span>10:00 ~ 9:00</span>
-        </Hour>
-        <Hour>
-          <h5>일</h5>
-          <span>10:00 ~ 9:00</span>
-        </Hour>
+        {Object.keys(workingHours).map((day, i) => {
+          return (
+            <Hour key={i}>
+              <h5>{convertToDay(day)}</h5>
+              <span>
+                {workingHours[day].startTime === 'none'
+                  ? '휴무'
+                  : workingHours[day].startTime +
+                    ' ~ ' +
+                    workingHours[day].endTime}
+              </span>
+            </Hour>
+          );
+        })}
       </HoursWrapper>
     </Container>
   );

--- a/src/redux/slices/storeSlice.js
+++ b/src/redux/slices/storeSlice.js
@@ -58,22 +58,22 @@ const storeSlice = createSlice({
   initialState: initialState,
   reducers: {
     setStoreName: (state, action) => {
-      state.storeName = action.payload;
+      state.info.storeName = action.payload;
     },
     setCategory: (state, action) => {
-      state.category = action.payload;
+      state.info.category = action.payload;
     },
     setWorkingHours: (state, action) => {
-      state.workingHours = action.payload;
+      state.info.workingHours = action.payload;
     },
     setNumber: (state, action) => {
-      state.number = action.payload;
+      state.info.number = action.payload;
     },
     setAddress: (state, action) => {
-      state.address = action.payload;
+      state.info.address = action.payload;
     },
     setAddressDetail: (state, action) => {
-      state.addressDetail = action.payload;
+      state.info.addressDetail = action.payload;
     },
   },
   extraReducers: (builder) => {

--- a/src/redux/thunks/getStoreInfo 2.js
+++ b/src/redux/thunks/getStoreInfo 2.js
@@ -1,0 +1,29 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { defaultInstance } from '../../api/axios';
+
+const getStoreInfo = createAsyncThunk('store/getStoreInfo', async (storeId) => {
+  try {
+    const res = await defaultInstance.get(`/api/owner/store/${storeId}/basic`);
+
+    if (res.data.isSuccess) {
+      const data = res.data.result;
+      const result = {
+        storeName: data.name,
+        number: data.telePhone,
+        address: data.location,
+        addressDetail: data.detailLocation,
+        category: data.category,
+        workingHours: {},
+      };
+
+      data.time.forEach((timeData) => {
+        result.workingHours[timeData.day] = timeData;
+      });
+      return result;
+    }
+  } catch (err) {
+    throw err;
+  }
+});
+
+export default getStoreInfo;


### PR DESCRIPTION
## 📍 작업 내용
- 매장관리 > 기본정보 redux 연동 오류 수정
- 홈화면 서버 연동 완료

<br/>

## 📍 구현 결과 (선택)
<img width="1440" alt="스크린샷 2024-02-18 오전 3 14 38" src="https://github.com/UMC-5th-Coumo/Coumo_Web/assets/121474189/af9ed527-3471-483c-bf73-54ecc276d890">


<br/>

## 📍 기타 사항
기본정보에서 매장 정보 수정 > 홈화면에 바로 반영되는 것 확인했습니다~!

<br/>
